### PR TITLE
Log-vars redesign

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelBaseEcon"
 uuid = "1d16192e-b65e-11ea-11ed-0789cee22d2f"
 authors = ["Atai Akunov <aakunov@bankofcanada.ca>", "Boyan Bejanov <bbejanov@bankofcanada.ca>", "Nicholas Labelle St-Pierre <labs@bankofcanada.ca>"]
-version = "0.3"
+version = "0.3.1-dev"
 
 [deps]
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -135,6 +135,7 @@ Base.getindex(vd::SSVarData, s) = getproperty(vd, Symbol(s))
 Base.setindex!(vd::SSVarData, val, i::Int) = setindex!(vd.value, val, i)
 Base.setindex!(vd::SSVarData, val, s) = setproperty!(vd, Symbol(s), val)
 
+Base.iterate(vd::SSVarData, args...) = Base.iterate(vd.value, args...)
 
 Base.show(io::IO, ::MIME"text/plan", vd::SSVarData) = show(io, vd)
 Base.show(io::IO, vd::SSVarData) = print(io, vd.name, " : ", NamedTuple{(:level, :slope)}(vd.value))

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -52,6 +52,7 @@ for sym ∈ (:shock, :log, :lin, :steady)
     end)
 end
 
+Symbol(s::ModelSymbol) = s.name
 Base.convert(::Type{Symbol}, v::ModelSymbol) = v.name
 Base.convert(::Type{ModelSymbol}, v::Symbol) = ModelSymbol(v)
 Base.convert(::Type{ModelSymbol}, v::Expr) = ModelSymbol(v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,6 +175,12 @@ end
     for s in (:p, :q, :r)
         @test m.:($s) isa ModelSymbol && issteady(m.:($s))
     end
+    @equations m begin
+        p[t] = 0
+    end
+    @initialize m
+    @test Symbol(m.variables[1]) == m.variables[1]
+    @test begin (l, s) = m.sstate.x; l == m.sstate.x.level && s == m.sstate.x.slope end
 end
 
 
@@ -375,7 +381,7 @@ end
         @variables m X
         @shocks m EX
         @equations m begin
-            @log X[t] = rho * X[t-1] + EX[t]
+            @log X[t] = rho * X[t - 1] + EX[t]
         end
         @initialize m
         @test length(m.equations) == 1 && islog(m.equations[1])


### PR DESCRIPTION
* In the steady state solver we now have `Vt = exp(V#lvl + t * V#slp)`
* `m.shift` has immediate effect (no need to re-call `@initialize m`)
* `printsstate()` shows type of variables and comments
* `@steadystate` with `@log`-variable now replaces `V` with `exp(V#lvl)`
* `@steadystate` unblocks expressions