### PR TITLE
Fix ModelVariable hash on Julia 1.7+

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -85,6 +85,7 @@ Base.:(==)(a::Symbol, b::ModelVariable) = a == b.name
 # The hash must be the same as the hash of the symbol, so that we can use
 # ModelVariable as index in a Dict with Symbol keys
 Base.hash(v::ModelVariable, h::UInt) = hash(v.name, h)
+Base.hash(v::ModelVariable) = hash(v.name)
 
 function Base.show(io::IO, v::ModelVariable)
     if get(io, :compact, false)


### PR DESCRIPTION
On Julia 1.7+, the Model fails to initialize because the variables are no longer matched to their equivalents in the equations. 

This is caused by a breaking [change ](https://github.com/JuliaLang/julia/pull/40935/commits/c47754e2598858927118f2f7474354f306d6a6eb) in Julia between versions 1.6 and 1.7 which optimized the one-argument hash function for symbols. 

Since the one-argument hash function for symbols now differs from the two-argument one, it is necessary to add the Base.hash equivalent for the one-argument form.

For a bit more context see here: https://github.com/JuliaLang/julia/issues/44007


