### PR TITLE
Add some more explicit precompilation 

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -9,7 +9,7 @@ with chunk size `N`.
     Internal function. Do not call directly
 
 """
-function precompile_funcs(N::Int)
+function precompile_dual_funcs(N::Int)
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
 
     tag = ModelBaseEconTag
@@ -32,10 +32,21 @@ function precompile_funcs(N::Int)
 
     precompile(ForwardDiff.extract_gradient!, (Type{tag}, mdr, dual)) || error("precompile")
     precompile(ForwardDiff.vector_mode_gradient!, (mdr, FunctionWrapper, Vector{Float64}, cfg)) || error("precompile")
+    precompile(ForwardDiff.gradient!, (DiffResults.MutableDiffResult{1, Float64, Tuple{Vector{Float64}}},
+                                       FunctionWrapper, Vector{Float64}, ForwardDiff.GradientConfig{ModelBaseEconTag, Float64, N, Vector{ForwardDiff.Dual{ModelBaseEconTag, Float64, N}}})) || error("precompile")
 
     return nothing
 end
 
 for i in 1:MAX_CHUNK_SIZE
-    precompile_funcs(i)
+    precompile_dual_funcs(i)
 end
+
+function precompile_other()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    precompile(Tuple{typeof(eval_RJ), Matrix{Float64}, Model}) || error("precompile")
+    precompile(Tuple{typeof(_update_eqn_params!), Function, Parameters{ModelParam}}) || error("precompile")
+    precompile(Tuple{typeof(eval_RJ), Matrix{Float64}, ModelEvaluationData{Equation, Vector{CartesianIndex{2}}, DynEqnEvalData0}}) || error("precompile")
+end
+
+precompile_other()


### PR DESCRIPTION
**Note**: This PR is made on top of https://github.com/bankofcanada/ModelBaseEcon.jl/pull/38


This takes the following benchmark of the FRB-US model
(measuring the time of the first call):

```
unique!(push!(LOAD_PATH, realpath("./models"))) # hide
using ModelBaseEcon
using FRBUS_VAR

m = FRBUS_VAR.model
nrows = 1 + m.maxlag + m.maxlead
ncols = length(m.allvars)
pt = zeros(nrows, ncols);
@time @eval eval_RJ(pt, m);
```

from 0.62s to 0.22s using Julia 1.9.0-beta4.