### PR TITLE
avoid calling `+` with variable number of arguments

### DIFF
--- a/src/metafuncs.jl
+++ b/src/metafuncs.jl
@@ -110,7 +110,7 @@ For example: `at_movsum(x[t], 3) = x[t] + x[t-1] + x[t-2]`.
 See also [`at_lag`](@ref).
 """
 at_movsum(expr::Expr, n::Integer) = MacroTools.unblock(
-    Expr(:call, :+, expr, (at_lag(expr, i) for i = 1:n-1)...)
+    split_nargs(Expr(:call, :+, expr, (at_lag(expr, i) for i = 1:n-1)...))
 )
 
 """
@@ -132,10 +132,10 @@ For example: `at_movsumew(x[t], 3, 0.7) = x[t] + 0.7*x[t-1] + 0.7^2x[t-2]`
 See also [`at_movavew`](@ref)
 """
 at_movsumew(expr::Expr, n::Integer, r) =
-    MacroTools.unblock(Expr(:call, :+, expr, (Expr(:call, :*, :(($r)^($i)), at_lag(expr, i)) for i = 1:n-1)...))
+    MacroTools.unblock(split_nargs(Expr(:call, :+, expr, (Expr(:call, :*, :(($r)^($i)), at_lag(expr, i)) for i = 1:n-1)...)))
 at_movsumew(expr::Expr, n::Integer, r::Real) =
     isapprox(r, 1.0) ? at_movsum(expr, n) :
-    MacroTools.unblock(Expr(:call, :+, expr, (Expr(:call, :*, r^i, at_lag(expr, i)) for i = 1:n-1)...))
+    MacroTools.unblock(split_nargs(Expr(:call, :+, expr, (Expr(:call, :*, r^i, at_lag(expr, i)) for i = 1:n-1)...)))
 
 """
     at_movavew(expr, n, r)
@@ -165,4 +165,3 @@ for sym in (:lag, :lead, :d, :dlog, :movsum, :movav, :movsumew, :movavew)
     end
     eval(qq)
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -473,10 +473,10 @@ end
     @test ModelBaseEcon.at_lag(:(x[t]), 0) == :(x[t])
     @test_throws ErrorException ModelBaseEcon.at_d(:(x[t]), 0, -1)
     @test ModelBaseEcon.at_d(:(x[t]), 3, 0) == :(((x[t] - 3 * x[t-1]) + 3 * x[t-2]) - x[t-3])
-    @test ModelBaseEcon.at_movsumew(:(x[t]), 3, 2.0) == :(x[t] + 2.0 * x[t-1] + 4.0 * x[t-2])
-    @test ModelBaseEcon.at_movsumew(:(x[t]), 3, :y) == :(x[t] + y^1 * x[t-1] + y^2 * x[t-2])
-    @test ModelBaseEcon.at_movavew(:(x[t]), 3, 2.0) == :((x[t] + 2.0 * x[t-1] + 4.0 * x[t-2]) / 7.0)
-    @test ModelBaseEcon.at_movavew(:(x[t]), 3, :y) == :(((x[t] + y^1 * x[t-1] + y^2 * x[t-2]) * (1 - y)) / (1 - y^3))
+    @test ModelBaseEcon.at_movsumew(:(x[t]), 3, 2.0) == :(x[t] + (2.0 * x[t-1] + 4.0 * x[t-2]))
+    @test ModelBaseEcon.at_movsumew(:(x[t]), 3, :y) == :(x[t] + (y^1 * x[t-1] + y^2 * x[t-2]))
+    @test ModelBaseEcon.at_movavew(:(x[t]), 3, 2.0) == :((x[t] + (2.0 * x[t-1] + 4.0 * x[t-2])) / 7.0)
+    @test ModelBaseEcon.at_movavew(:(x[t]), 3, :y) == :(((x[t] + (y^1 * x[t-1] + y^2 * x[t-2])) * (1 - y)) / (1 - y^3))
 end
 module MetaTest
 using ModelBaseEcon
@@ -598,34 +598,34 @@ end
     @equations mod begin
         x[t-1] = sx[t+1]
         @lag(x[t]) = @lag(sx[t+2])
-        # 
+        #
         x[t-1] + a = sx[t+1] + 3
         @lag(x[t] + a) = @lag(sx[t+2] + 3)
-        # 
+        #
         x[t-2] = sx[t]
         @lag(x[t], 2) = @lead(sx[t-2], 2)
-        # 
+        #
         x[t] - x[t-1] = x[t+1] - x[t] + sx[t]
         @d(x[t]) = @d(x[t+1]) + sx[t]
-        # 
+        #
         (x[t] - x[t+1]) - (x[t-1] - x[t]) = sx[t]
         @d(x[t] - x[t+1]) = sx[t]
-        # 
+        #
         x[t] - x[t-2] = sx[t]
         @d(x[t], 0, 2) = sx[t]
-        # 
+        #
         x[t] - 2x[t-1] + x[t-2] = sx[t]
         @d(x[t], 2) = sx[t]
-        # 
+        #
         x[t] - x[t-1] - x[t-2] + x[t-3] = sx[t]
         @d(x[t], 1, 2) = sx[t]
-        # 
+        #
         log(x[t] - x[t-2]) - log(x[t-1] - x[t-3]) = sx[t]
         @dlog(@d(x[t], 0, 2)) = sx[t]
-        # 
+        #
         (x[t] + 0.3x[t+2]) + (x[t-1] + 0.3x[t+1]) + (x[t-2] + 0.3x[t]) = 0
         @movsum(x[t] + 0.3x[t+2], 3) = 0
-        # 
+        #
         ((x[t] + 0.3x[t+2]) + (x[t-1] + 0.3x[t+1]) + (x[t-2] + 0.3x[t])) / 3 = 0
         @movav(x[t] + 0.3x[t+2], 3) = 0
     end
@@ -902,7 +902,7 @@ end
     end
     @test length(out) == 3
     @test length(split(out[end], "=")) == 2
-    # 
+    #
     @test propertynames(ss) == tuple(m.allvars...)
     @test ss.pinf.level == ss.pinf.data[1]
     @test ss.pinf.slope == ss.pinf.data[2]
@@ -1017,7 +1017,7 @@ end
             log(x[t]) = lx[t] + s2[t+1]
         end
         @initialize m
-        # 
+        #
         @test nvariables(m) == 2
         @test nshocks(m) == 2
         @test nequations(m) == 2
@@ -1025,7 +1025,7 @@ end
         @test neqns(ss) == 4
         eq1, eq2, eq3, eq4 = ss.equations
         @test length(ss.values) == 2 * length(m.allvars)
-        # 
+        #
         # test with eq1
         ss.lx.data .= [1.5, 0.2]
         ss.x.data .= [0.0, 0.2]


### PR DESCRIPTION
Julia parses `a + b + c + ...` as `+(a, b, c, ...)` which ends up calling a function with a variable number of arguments (`afoldl`). This means that we compile many functions of the following kind:

```julia
precompile(Tuple{typeof(Base.afoldl), typeof(Base.:(+)), Vararg{ForwardDiff.Dual{f, Float64, 4}, 30}})
precompile(Tuple{typeof(Base.afoldl), typeof(Base.:(+)), Vararg{ForwardDiff.Dual{f, Float64, 4}, 29}})
precompile(Tuple{typeof(Base.afoldl), typeof(Base.:(+)), Vararg{ForwardDiff.Dual{f, Float64, 4}, 13}})
precompile(Tuple{typeof(Base.afoldl), typeof(Base.:(+)), Vararg{ForwardDiff.Dual{f, Float64, 4}, 12}})
```

since this n-arg structure is commonly introduced by e.g `@movav`.


This PR introduces a function that can be applied to an expression that splits up an n-arg expression like `+(a, b, c, ...)` into `a +(b, +(c, ...)))`. This means that there will only be calls to `+` with two arguments, saving many otherwise required compilations.

This takes the following benchmark of the FRB-US model (measuring the time of the first call):

```julia
unique!(push!(LOAD_PATH, realpath("./models")))
using ModelBaseEcon
using FRBUS_VAR

m = FRBUS_VAR.model
nrows = 1 + m.maxlag + m.maxlead
ncols = length(m.allvars)
pt = zeros(nrows, ncols);
@time @eval eval_RJ(pt, m);
```

from 0.22s to 0.08s on Julia 1.9.0-beta4 (using https://github.com/bankofcanada/ModelBaseEcon.jl/pull/39 as the base).

Now, it is, of course, silly that `Julia` does this type of parsing since it is so harmful but presumably the choice was made a long time ago when the impact was not realized so for now, let's just work around it.