### PR TITLE
Fix deepcopy of Parameters

### DIFF
--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -93,7 +93,18 @@ macro parameters()
 end
 
 # To deepcopy() Parameters, we make a new Ref to the same module and a deepcopy of contents.
-Base.deepcopy_internal(p::Parameters, stackdict::IdDict) = Parameters(Ref(p.mod[]), Base.deepcopy_internal(p.contents, stackdict), Ref(p.rev[]))
+function Base.deepcopy_internal(p::Parameters, stackdict::IdDict) 
+    if haskey(stackdict, p)
+        return stackdict[p]::typeof(p)
+    end
+    p_copy = Parameters(
+        Ref(p.mod[]), 
+        Base.deepcopy_internal(p.contents, stackdict), 
+        Ref(p.rev[])
+    )
+    stackdict[p] = p_copy
+    return p_copy
+end
 
 # The following functionality is forwarded to the contents
 # iteration

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -818,6 +818,25 @@ end
     @test islinearized(m)
 end
 
+@testset "E1.params (deepcopy)" begin
+    let m = deepcopy(E1.model)
+        @test propertynames(m.parameters) == (:α, :β)
+        @test peval(m, :α) == 0.5
+        m.β = @link 1.0 - α
+        m.parameters.beta = @alias β
+        for α = 0.0:0.1:1.0
+            m.α = α
+            test_eval_RJ(m, [0.0], [-α 1.0 -m.beta 0.0 -1.0 0.0;])
+        end
+        @test_logs (:warn, r"Model does not have parameters*"i) assign_parameters!(m, γ=0)
+    end
+    let io = IOBuffer(), m = deepcopy(E1.model)
+        show(io, m.parameters)
+        @test length(split(String(take!(io)), '\n')) == 1
+        show(io, MIME"text/plain"(), m.parameters)
+        @test length(split(String(take!(io)), '\n')) == 3
+    end
+end
 
 @testset "E1.params" begin
     let m = E1.model

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -755,6 +755,12 @@ function compare_RJ_R!_(m::Model)
 end
 
 @using_example E1
+@testset "Deepcopy" begin
+    @test E1.model.evaldata[:default].params[] === E1.model.parameters
+    m1 = deepcopy(E1.model)
+    @test m1.evaldata[:default].params[] === m1.parameters
+end
+
 @testset "E1" begin
     @test length(E1.model.parameters) == 2
     @test length(E1.model.variables) == 1


### PR DESCRIPTION
This commit fixes an issue where deepcopies of models would exhibit behavior different from the original due to an incomplete implementation of `deepcopy_internal` for Parameters which did not update the stackdict. This resulted in broken references buried within the functions of the ssequations and the evaldata object. 

Additional tests were also added.

The text below is obsolete, it explains some of the changes made in the earlier commits, undone in the latest commit.

---
**Description of fix in earlier commits.**
In the SteadyStateData, the broken reference is to the model itself within an `SSEqnData` object which gets created for the creation of the resid functions, but is discarded and subsequently no longer exists outside of those functions.

```
function sseqn_resid_RJ(s::SSEqnData)
    function _resid(pt::Vector{<:Real})
        _update_eqn_params!(s.eqn.eval_resid, s.model[].parameters)
        return s.eqn.eval_resid(__to_dyn_pt(pt, s))
    end
    function _RJ(pt::Vector{<:Real})
        _update_eqn_params!(s.eqn.eval_resid, s.model[].parameters)
        R, jj = s.eqn.eval_RJ(__to_dyn_pt(pt, s))
        return R, __to_ssgrad(pt, jj, s)
    end
    return _resid, _RJ
end


function make_sseqn(model::AbstractModel, eqn::Equation, shift::Bool)
    ...
    let sseqndata = SSEqnData(shift, Ref(model), JT, eqn)
        return SteadyStateEquation(type, vinds, vsyms, eqn.expr, sseqn_resid_RJ(sseqndata)...)
    end
end
```

Perhaps there is a clever way to get at it and update it, but the approach taken in the PR is to reinitialize the steadystate in the copied object and then copy over the steadystate values and mask from the original object.

For the `ModelEvaluationData` the reference is in the object itself which gets passed to the respective functions so it is enough to make deepcopies of the `ModelEvaluationData` instances with the reference corrected. This approach was about twice as fast as clearing and recreating the ModelEvaluationData.