### PR TITLE
add a `load_model` function and use it to allow loading multiple versions of models simultaneously

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
@@ -16,6 +17,7 @@ DiffResults = "1.0"
 ForwardDiff = "0.10"
 MacroTools = "0.5"
 OrderedCollections = "1.4"
+Scratch = "1"
 julia = "1.7"
 
 [extras]

--- a/src/ModelBaseEcon.jl
+++ b/src/ModelBaseEcon.jl
@@ -8,7 +8,7 @@
 """
     ModelBaseEcon
 
-This package is part of the StateSpaceEcon ecosystem. 
+This package is part of the StateSpaceEcon ecosystem.
 It provides the basic elements needed for model definition.
 StateSpaceEcon works with model objects defined with ModelBaseEcon.
 """
@@ -16,6 +16,7 @@ module ModelBaseEcon
 
 using OrderedCollections
 using MacroTools
+using Scratch
 using SparseArrays
 using DiffResults
 using ForwardDiff

--- a/src/model.jl
+++ b/src/model.jl
@@ -5,7 +5,7 @@
 # All rights reserved.
 ##################################################################################
 
-export Model
+export Model, load_model
 
 const defaultoptions = Options(
     shift=10,
@@ -64,7 +64,7 @@ mutable struct Model <: AbstractModel
     shocks::Vector{ModelVariable}
     # transition equations
     equations::Vector{Equation}
-    # parameters 
+    # parameters
     parameters::Parameters
     # auto-exogenize mapping of variables and shocks
     autoexogenize::Dict{Symbol,Symbol}
@@ -79,7 +79,7 @@ mutable struct Model <: AbstractModel
     evaldata::LittleDict{Symbol,AbstractModelEvaluationData}
     # data slot to be used by the solver (in StateSpaceEcon)
     solverdata::LittleDict{Symbol,Any}
-    # 
+    #
     # constructor of an empty model
     Model(opts::Options) = new(merge(defaultoptions, opts),
         ModelFlags(), SteadyStateData(), false, [], [], [], Parameters(), Dict(), 0, 0, [], [],
@@ -362,7 +362,7 @@ end
 ################################################################
 # The macros used in the model definition.
 
-# Note: These macros simply store the information into the corresponding 
+# Note: These macros simply store the information into the corresponding
 # arrays within the model instance. The actual processing is done in @initialize
 
 export @variables, @logvariables, @neglogvariables, @steadyvariables, @exogenous, @shocks
@@ -376,7 +376,7 @@ export @parameters, @equations, @autoshocks, @autoexogenize
         ...
     end
 
-Declare the names of variables in the model. 
+Declare the names of variables in the model.
 
 In the `begin-end` version the variable names can be preceeded by a description
 (like a docstring) and flags like `@log`, `@steady`, `@exog`, etc. See
@@ -437,7 +437,7 @@ end
 """
     @exogenous
 
-Like [`@variables`](@ref), but the names declared with `@exogenous` are 
+Like [`@variables`](@ref), but the names declared with `@exogenous` are
 exogenous.
 """
 macro exogenous(model, block::Expr)
@@ -451,7 +451,7 @@ end
 """
     @shocks
 
-Like [`@variables`](@ref), but the names declared with `@shocks` are 
+Like [`@variables`](@ref), but the names declared with `@shocks` are
 shocks.
 """
 macro shocks(model, block::Expr)
@@ -487,7 +487,7 @@ end
         ...
     end
 
-Declare and define the model parameters. 
+Declare and define the model parameters.
 
 The parameters must have values. Provide the information in a series of
 assignment statements wrapped inside a begin-end block. Use `@link` and `@alias`
@@ -595,7 +595,7 @@ function process_equation(model::Model, expr::Expr;
     flags=EqnFlags(),
     doc="")
 
-    # a list of all known time series 
+    # a list of all known time series
     allvars = model.allvars
 
     # keep track of model parameters used in expression
@@ -629,12 +629,12 @@ function process_equation(model::Model, expr::Expr;
 
     ###################
     #    process(expr)
-    # 
+    #
     # Process the expression, performing various tasks.
     #  + keep track of mentions of parameters and variables (including shocks)
     #  + remove line numbers from expression, but keep track so we can insert it into the residual functions
     #  + for each time-referenece of variable, create a dummy symbol that will be used in constructing the residual functions
-    # 
+    #
     # leave numbers alone
     process(num::Number) = num
     # store line number and discard it from the expression
@@ -666,7 +666,7 @@ function process_equation(model::Model, expr::Expr;
     end
     # Main version of process() - it's recursive
     function process(ex::Expr)
-        # is this a docstring? 
+        # is this a docstring?
         if ex.head == :macrocall && ex.args[1] == doc_macro
             push!(source, ex.args[2])
             doc *= ex.args[3]
@@ -757,9 +757,9 @@ function process_equation(model::Model, expr::Expr;
 
     ##################
     #    make_residual_expression(expr)
-    # 
+    #
     # Convert a processed equation into an expression that evaluates the residual.
-    # 
+    #
     #  + each mention of a time-reference is replaced with its symbol
     make_residual_expression(any) = any
     make_residual_expression(name::Symbol) = haskey(model.parameters, name) ? prefs[name] : name
@@ -844,14 +844,14 @@ function add_equation!(model::Model, expr::Expr; modelmodule::Module=moduleof(mo
     done_equalsign = Ref(false)
 
     ##################################
-    # We preprocess() the expression looking for substitutions. 
+    # We preprocess() the expression looking for substitutions.
     # If we find one, we create an auxiliary variable and equation.
     # We also keep track of line number, so we can label the aux equation as
     # defined on the same line.
     # We also look for doc string and flags (@log, @lin)
-    # 
-    # We make sure to make a copy of the expression and not to overwrite it. 
-    # 
+    #
+    # We make sure to make a copy of the expression and not to overwrite it.
+    #
     preprocess(any) = any
     function preprocess(line::LineNumberNode)
         push!(source, line)
@@ -897,10 +897,10 @@ function add_equation!(model::Model, expr::Expr; modelmodule::Module=moduleof(mo
         if getoption!(model; substitutions=true)
             local arg
             matched = @capture(ret, log(arg_))
-            # is it log(arg) 
+            # is it log(arg)
             if matched && isa(arg, Expr)
                 local var1, var2, ind1, ind2
-                # is it log(x[t]) ? 
+                # is it log(x[t]) ?
                 matched = @capture(arg, var1_[ind1_])
                 if matched
                     mv = model.:($var1)
@@ -1090,4 +1090,51 @@ function update_auxvars(data::AbstractArray{Float64,2}, model::Model;
         end
     end
     return result
+end
+
+const model_cache_dir = Ref{String}()
+function __init__()
+    model_cache_dir[] = @get_scratch!("model_path")
+end
+
+"""
+    load_model(model_path::AbstractString, [name::AbstractString])
+
+Loads and return an instance of a model at path `model_path`.
+If a model with that name is already loaded, an instance of the loaded model is returned.
+Models are piggy backing on the
+"""
+function load_model(model_path::AbstractString, name::Union{Nothing,AbstractString}=nothing)
+    file = basename(model_path)
+    if name === nothing
+        # TODO: Error handling
+        name = splitext(file)[1]
+    end
+
+    # Check if model of that name has already been loaded in session
+    loaded_mod = get(Base.loaded_modules, Base.PkgId(nothing, name), nothing)
+    if loaded_mod !== nothing
+        @warn("a model with the name `$name` is already loaded, returning the already loaded modek")
+        return loaded_mod.model
+    end
+
+    scratch_model_path = joinpath(model_cache_dir[], name * ".jl")
+    module_name = splitext(file)[1]
+    module_chunk = string("module ", module_name)
+    model_content = read(model_path, String)
+    @assert occursin(module_chunk, model_content)
+    new_model_content = replace(model_content, module_chunk => string("module ", name))
+    if !isfile(scratch_model_path) || read(scratch_model_path, String) != new_model_content
+        write(scratch_model_path, new_model_content)
+    end
+
+    # Setup the load path and load the model as a julia package
+    old_load_path = copy(LOAD_PATH)
+    push!(LOAD_PATH, model_cache_dir[])
+    try
+        mod = Base.require(Base.PkgId(nothing, name))
+        return mod.model
+    finally
+        copy!(LOAD_PATH, old_load_path)
+    end
 end


### PR DESCRIPTION
This is a proof of concept for a slightly more structured model loading than the
current one which is based on modifying the `LOAD_PATH` and loading the module
as a package. The issue with the current system is that you can not load
multiple models with the same name since the Julia namespace for files loaded as
packages is just the name of the module. However, using the Julia package system
for the models means that it can be precompiled which can generate big time
savings over multiple sessions where the same model is loaded.

This PR creates a new `load_model` function with the intention of keeping the
advantages of precompiling the models which also allow loading multiple models
of the same name. This is done by having an optional argument to `load_model`
that can give a separate "alias" for the model. When this is given, the `module
Model` part in the model is replaced with the alias. The model file is copied
to a scratch space before getting loaded in order to not pollute the folder where
they are loaded from.

The drawbacks to this approach are:
- Splitting a model into multiple files with `include` will not work out of the box.
- Stacktraces etc will also point to this generated file in the scratch space

Below is a usage example:

```julia
[ Info: Precompiling simple_RBC [top-level]
6 variable(s): C, K, L, w, r, A
1 shock(s): ea
7 parameter(s): g = 0.015, α = 0.33, γ = 0
    δ = 0.1, λ = 0.97, ρ = 0.03, β = @link 1 / (1 + ρ)
6 equations(s):
   E1:   @log 1 / C[t] = β * (1 / (C[t + 1] * (1 + g))) * ((r[t + 1] + 1) - δ)
   ...

In [3]: RBC2 = load_model("../2.simple_RBC/simple_RBC.jl", "simple_RBC2")
[ Info: Precompiling simple_RBC2 [top-level]
6 variable(s): C, K, L, w, r, A
1 shock(s): ea
7 parameter(s): g = 0.015, α = 0.33, γ = 0
    δ = 0.1, λ = 0.97, ρ = 0.03, β = @link 1 / (1 + ρ)
6 equations(s):
   E1:   @log 1 / C[t] = β * (1 / (C[t + 1] * (1 + g))) * ((r[t + 1] + 1) - δ)
...
```

Since this is the first time the model is loaded it has to be precompiled.
And a model with a different alias also need to be precompiled.

In a follow up session, the models are already precompiled and load quickly:

```julia
julia> RBC = load_model("../2.simple_RBC/simple_RBC.jl");

julia> RBC2 = load_model("../2.simple_RBC/simple_RBC.jl", "simple_RBC2");
```
