### PR TITLE
Remove training whitespace on select files

### DIFF
--- a/src/ModelBaseEcon.jl
+++ b/src/ModelBaseEcon.jl
@@ -8,7 +8,7 @@
 """
     ModelBaseEcon
 
-This package is part of the StateSpaceEcon ecosystem. 
+This package is part of the StateSpaceEcon ecosystem.
 It provides the basic elements needed for model definition.
 StateSpaceEcon works with model objects defined with ModelBaseEcon.
 """

--- a/src/equation.jl
+++ b/src/equation.jl
@@ -16,7 +16,7 @@ msg(::EqnNotReadyError) = "Equation not ready to use."
 hint(::EqnNotReadyError) = "Call `@initialize model` or `add_equation!()` first."
 
 ###############################################
-# 
+#
 
 # Equation expressions typed by the user are of course valid equations, however
 # during processing we use recursive algorithms, with the bottom of the recursion
@@ -70,7 +70,7 @@ there's no need to users to call these functions directly. They are used
 internally by the solvers.
 """
 struct Equation <: AbstractEquation
-    ### Implementation note 
+    ### Implementation note
     # During the phase of definition of the Model, this type simply stores the expression
     # entered by the user. During @initialize(), the full data structure is constructed.
     # We need this, because the construction of the equation requires information from
@@ -98,7 +98,7 @@ struct Equation <: AbstractEquation
     eval_RJ::Function     # Function evaluating the residual and its gradient
 end
 
-# 
+#
 # dummy constructor - just stores the expresstion without any processing
 Equation(expr::ExtExpr) = Equation("", EqnFlags(), expr, Expr(:block), LittleDict(), LittleDict(), LittleDict(), eqnnotready, eqnnotready)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -64,7 +64,7 @@ mutable struct Model <: AbstractModel
     shocks::Vector{ModelVariable}
     # transition equations
     equations::Vector{Equation}
-    # parameters 
+    # parameters
     parameters::Parameters
     # auto-exogenize mapping of variables and shocks
     autoexogenize::Dict{Symbol,Symbol}
@@ -79,7 +79,7 @@ mutable struct Model <: AbstractModel
     evaldata::LittleDict{Symbol,AbstractModelEvaluationData}
     # data slot to be used by the solver (in StateSpaceEcon)
     solverdata::LittleDict{Symbol,Any}
-    # 
+    #
     # constructor of an empty model
     Model(opts::Options) = new(merge(defaultoptions, opts),
         ModelFlags(), SteadyStateData(), false, [], [], [], Parameters(), Dict(), 0, 0, [], [],
@@ -362,7 +362,7 @@ end
 ################################################################
 # The macros used in the model definition.
 
-# Note: These macros simply store the information into the corresponding 
+# Note: These macros simply store the information into the corresponding
 # arrays within the model instance. The actual processing is done in @initialize
 
 export @variables, @logvariables, @neglogvariables, @steadyvariables, @exogenous, @shocks
@@ -376,7 +376,7 @@ export @parameters, @equations, @autoshocks, @autoexogenize
         ...
     end
 
-Declare the names of variables in the model. 
+Declare the names of variables in the model.
 
 In the `begin-end` version the variable names can be preceeded by a description
 (like a docstring) and flags like `@log`, `@steady`, `@exog`, etc. See
@@ -437,7 +437,7 @@ end
 """
     @exogenous
 
-Like [`@variables`](@ref), but the names declared with `@exogenous` are 
+Like [`@variables`](@ref), but the names declared with `@exogenous` are
 exogenous.
 """
 macro exogenous(model, block::Expr)
@@ -451,7 +451,7 @@ end
 """
     @shocks
 
-Like [`@variables`](@ref), but the names declared with `@shocks` are 
+Like [`@variables`](@ref), but the names declared with `@shocks` are
 shocks.
 """
 macro shocks(model, block::Expr)
@@ -487,7 +487,7 @@ end
         ...
     end
 
-Declare and define the model parameters. 
+Declare and define the model parameters.
 
 The parameters must have values. Provide the information in a series of
 assignment statements wrapped inside a begin-end block. Use `@link` and `@alias`
@@ -595,7 +595,7 @@ function process_equation(model::Model, expr::Expr;
     flags=EqnFlags(),
     doc="")
 
-    # a list of all known time series 
+    # a list of all known time series
     allvars = model.allvars
 
     # keep track of model parameters used in expression
@@ -629,12 +629,12 @@ function process_equation(model::Model, expr::Expr;
 
     ###################
     #    process(expr)
-    # 
+    #
     # Process the expression, performing various tasks.
     #  + keep track of mentions of parameters and variables (including shocks)
     #  + remove line numbers from expression, but keep track so we can insert it into the residual functions
     #  + for each time-referenece of variable, create a dummy symbol that will be used in constructing the residual functions
-    # 
+    #
     # leave numbers alone
     process(num::Number) = num
     # store line number and discard it from the expression
@@ -666,7 +666,7 @@ function process_equation(model::Model, expr::Expr;
     end
     # Main version of process() - it's recursive
     function process(ex::Expr)
-        # is this a docstring? 
+        # is this a docstring?
         if ex.head == :macrocall && ex.args[1] == doc_macro
             push!(source, ex.args[2])
             doc *= ex.args[3]
@@ -757,9 +757,9 @@ function process_equation(model::Model, expr::Expr;
 
     ##################
     #    make_residual_expression(expr)
-    # 
+    #
     # Convert a processed equation into an expression that evaluates the residual.
-    # 
+    #
     #  + each mention of a time-reference is replaced with its symbol
     make_residual_expression(any) = any
     make_residual_expression(name::Symbol) = haskey(model.parameters, name) ? prefs[name] : name
@@ -844,14 +844,14 @@ function add_equation!(model::Model, expr::Expr; modelmodule::Module=moduleof(mo
     done_equalsign = Ref(false)
 
     ##################################
-    # We preprocess() the expression looking for substitutions. 
+    # We preprocess() the expression looking for substitutions.
     # If we find one, we create an auxiliary variable and equation.
     # We also keep track of line number, so we can label the aux equation as
     # defined on the same line.
     # We also look for doc string and flags (@log, @lin)
-    # 
-    # We make sure to make a copy of the expression and not to overwrite it. 
-    # 
+    #
+    # We make sure to make a copy of the expression and not to overwrite it.
+    #
     preprocess(any) = any
     function preprocess(line::LineNumberNode)
         push!(source, line)
@@ -897,10 +897,10 @@ function add_equation!(model::Model, expr::Expr; modelmodule::Module=moduleof(mo
         if getoption!(model; substitutions=true)
             local arg
             matched = @capture(ret, log(arg_))
-            # is it log(arg) 
+            # is it log(arg)
             if matched && isa(arg, Expr)
                 local var1, var2, ind1, ind2
-                # is it log(x[t]) ? 
+                # is it log(x[t]) ?
                 matched = @capture(arg, var1_[ind1_])
                 if matched
                     mv = model.:($var1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -598,34 +598,34 @@ end
     @equations mod begin
         x[t-1] = sx[t+1]
         @lag(x[t]) = @lag(sx[t+2])
-        # 
+        #
         x[t-1] + a = sx[t+1] + 3
         @lag(x[t] + a) = @lag(sx[t+2] + 3)
-        # 
+        #
         x[t-2] = sx[t]
         @lag(x[t], 2) = @lead(sx[t-2], 2)
-        # 
+        #
         x[t] - x[t-1] = x[t+1] - x[t] + sx[t]
         @d(x[t]) = @d(x[t+1]) + sx[t]
-        # 
+        #
         (x[t] - x[t+1]) - (x[t-1] - x[t]) = sx[t]
         @d(x[t] - x[t+1]) = sx[t]
-        # 
+        #
         x[t] - x[t-2] = sx[t]
         @d(x[t], 0, 2) = sx[t]
-        # 
+        #
         x[t] - 2x[t-1] + x[t-2] = sx[t]
         @d(x[t], 2) = sx[t]
-        # 
+        #
         x[t] - x[t-1] - x[t-2] + x[t-3] = sx[t]
         @d(x[t], 1, 2) = sx[t]
-        # 
+        #
         log(x[t] - x[t-2]) - log(x[t-1] - x[t-3]) = sx[t]
         @dlog(@d(x[t], 0, 2)) = sx[t]
-        # 
+        #
         (x[t] + 0.3x[t+2]) + (x[t-1] + 0.3x[t+1]) + (x[t-2] + 0.3x[t]) = 0
         @movsum(x[t] + 0.3x[t+2], 3) = 0
-        # 
+        #
         ((x[t] + 0.3x[t+2]) + (x[t-1] + 0.3x[t+1]) + (x[t-2] + 0.3x[t])) / 3 = 0
         @movav(x[t] + 0.3x[t+2], 3) = 0
     end
@@ -927,7 +927,7 @@ end
     end
     @test length(out) == 3
     @test length(split(out[end], "=")) == 2
-    # 
+    #
     @test propertynames(ss) == tuple(m.allvars...)
     @test ss.pinf.level == ss.pinf.data[1]
     @test ss.pinf.slope == ss.pinf.data[2]
@@ -1042,7 +1042,7 @@ end
             log(x[t]) = lx[t] + s2[t+1]
         end
         @initialize m
-        # 
+        #
         @test nvariables(m) == 2
         @test nshocks(m) == 2
         @test nequations(m) == 2
@@ -1050,7 +1050,7 @@ end
         @test neqns(ss) == 4
         eq1, eq2, eq3, eq4 = ss.equations
         @test length(ss.values) == 2 * length(m.allvars)
-        # 
+        #
         # test with eq1
         ss.lx.data .= [1.5, 0.2]
         ss.x.data .= [0.0, 0.2]


### PR DESCRIPTION
This PR removes trailing whitespace from files which form part of other current PRs. If merged, it will make the diff on these other files easier to read/understand.

A separate PR will be created for removing trailing whitespace from all source files.