### PR TITLE
remove trailing whitespace

### DIFF
--- a/examples/E3nl.jl
+++ b/examples/E3nl.jl
@@ -3,10 +3,10 @@
 Simple model with 3 variables, 3 shocks and 3 transition equations.
 Like E2, but with more lags/leads.
 
-The NL version is artificially made non-linear by taking one of the 
-equations (pinf[t]=rhs...) and rewriting it as exp(pinf[t])=exp(rhs...). 
-The solution of E3nl is identical to the linear E3 and can be used for 
-testing of the linearization solver. 
+The NL version is artificially made non-linear by taking one of the
+equations (pinf[t]=rhs...) and rewriting it as exp(pinf[t])=exp(rhs...).
+The solution of E3nl is identical to the linear E3 and can be used for
+testing of the linearization solver.
 """
 module  E3nl
 

--- a/examples/E6.jl
+++ b/examples/E6.jl
@@ -10,8 +10,8 @@ model = Model()
 model.flags.linear = true
 
 @parameters model begin
-    p_dlp = 0.0050000000000000 
-    p_dly = 0.0045000000000000 
+    p_dlp = 0.0050000000000000
+    p_dly = 0.0045000000000000
 end
 
 @variables model begin

--- a/examples/E7.jl
+++ b/examples/E7.jl
@@ -11,10 +11,10 @@ model.flags.linear = false
 model.substitutions = true
 
 @parameters model begin
-    delta = 0.1000000000000000 
-    p_dlc_ss = 0.0040000000000000 
-    p_dlinv_ss = 0.0040000000000000 
-    p_growth = 0.0040000000000000 
+    delta = 0.1000000000000000
+    p_dlc_ss = 0.0040000000000000
+    p_dlinv_ss = 0.0040000000000000
+    p_growth = 0.0040000000000000
 end
 
 @variables model begin

--- a/examples/E7A.jl
+++ b/examples/E7A.jl
@@ -11,10 +11,10 @@ model.flags.linear = false
 model.options.substitutions = false
 
 @parameters model begin
-    delta = 0.1000000000000000 
-    p_dlc_ss = 0.0040000000000000 
-    p_dlinv_ss = 0.0040000000000000 
-    p_growth = 0.0040000000000000 
+    delta = 0.1000000000000000
+    p_dlc_ss = 0.0040000000000000
+    p_dlinv_ss = 0.0040000000000000
+    p_growth = 0.0040000000000000
 end
 
 @variables model begin

--- a/examples/S1.jl
+++ b/examples/S1.jl
@@ -12,9 +12,9 @@ model.flags.linear = true
 @shocks model b_shk c_shk
 
 @parameters model begin
-    a_ss = 1.2 
-    α = 0.5 
-    β = 0.8 
+    a_ss = 1.2
+    α = 0.5
+    β = 0.8
     q = 2
 end
 

--- a/src/ModelBaseEcon.jl
+++ b/src/ModelBaseEcon.jl
@@ -8,7 +8,7 @@
 """
     ModelBaseEcon
 
-This package is part of the StateSpaceEcon ecosystem. 
+This package is part of the StateSpaceEcon ecosystem.
 It provides the basic elements needed for model definition.
 StateSpaceEcon works with model objects defined with ModelBaseEcon.
 """

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -15,7 +15,7 @@ Implements the [`Options`](@ref) data structure.
   * [`Options`](@ref)
   * [`getoption`](@ref) - read the value of an option
   * [`getoption!`](@ref) - if not present, also create an option
-  * [`setoption!`](@ref) - create or update the value of an option 
+  * [`setoption!`](@ref) - create or update the value of an option
 
 """
 module OptionsMod
@@ -54,7 +54,7 @@ Options:
 
 ```
 """
-struct Options 
+struct Options
     contents::Dict{Symbol,Any}
     # Options() = new(Dict())
     Options(c::Dict{Symbol,<:Any}) = new(c)
@@ -81,20 +81,20 @@ Options(pairs::Pair{<:AbstractString,<:Any}...) = Options(Dict(Symbol(k) => v fo
 Construct an Options instance as an exact copy of an existing instance.
 """
 Options(opts::Options) = Options(deepcopy(Dict(opts.contents)))
-    
+
 ############
 # compare
 
 Base.:(==)(opts::Options, opts2::Options) = opts.contents == opts2.contents
 Base.:(==)(opts::Dict, opts2::Options) = opts == opts2.contents
 Base.:(==)(opts::Options, opts2::Dict) = opts.contents == opts2
-    
+
 ############
 # merge
 
 """
     merge(o1::Options, o2::Options, ...)
-    
+
 Merge the given Options instances into a new Options instance.
 If the same option key exists in more than one instance, keep the value from
 the last one.
@@ -117,7 +117,7 @@ Base.propertynames(opts::Options) = tuple(keys(opts.contents)...)
 
 Base.setproperty!(opts::Options, name::Symbol, val) = opts.contents[name] = val
 
-Base.getproperty(opts::Options, name::Symbol) = 
+Base.getproperty(opts::Options, name::Symbol) =
     name ∈ fieldnames(Options) ? getfield(opts, name) :
     name ∈ keys(opts.contents) ? opts.contents[name]  :
                                  error("Option $name not set.");
@@ -135,7 +135,7 @@ function Base.show(io::IO, opts::Options)
     print(io, ")")
 end
 
-function Base.show(io::IO, ::MIME"text/plain", opts::Options) 
+function Base.show(io::IO, ::MIME"text/plain", opts::Options)
     recur_io = IOContext(io, :SHOWN_SET => opts.contents,
                              :typeinfo => eltype(opts.contents),
                              :compact => get(io, :compact, true))
@@ -175,7 +175,7 @@ if the name of the option is not a valid identifier.
 """
 function getoption end
 function getoption(opts::Options; kwargs...)
-    if length(kwargs) == 1 
+    if length(kwargs) == 1
         return get(opts.contents, first(kwargs)...)
     else
         return tuple((get(opts.contents, kv...) for kv in kwargs)...)
@@ -201,7 +201,7 @@ helpful if the name of the option is not a valid identifier.
 """
 function getoption! end
 function getoption!(opts::Options; kwargs...)
-    if length(kwargs) == 1 
+    if length(kwargs) == 1
         return get!(opts.contents, first(kwargs)...)
     else
         return tuple((get!(opts.contents, kv...) for kv in kwargs)...)

--- a/src/Timer.jl
+++ b/src/Timer.jl
@@ -36,15 +36,15 @@ using Printf
 export @timer, inittimer, printtimer, stoptimer
 
 """
-    timerData 
-    
+    timerData
+
 Stores timing data.
-    
+
 !!! note
     For internal use. Do not modify directly.
 
 If equal to `nothing`, timing is disabled.
-Otherwise, contains a "database" of timing data in the 
+Otherwise, contains a "database" of timing data in the
 form of a Dict.
 """
 global timerData = nothing

--- a/src/equation.jl
+++ b/src/equation.jl
@@ -16,7 +16,7 @@ msg(::EqnNotReadyError) = "Equation not ready to use."
 hint(::EqnNotReadyError) = "Call `@initialize model` or `add_equation!()` first."
 
 ###############################################
-# 
+#
 
 # Equation expressions typed by the user are of course valid equations, however
 # during processing we use recursive algorithms, with the bottom of the recursion
@@ -70,7 +70,7 @@ there's no need to users to call these functions directly. They are used
 internally by the solvers.
 """
 struct Equation <: AbstractEquation
-    ### Implementation note 
+    ### Implementation note
     # During the phase of definition of the Model, this type simply stores the expression
     # entered by the user. During @initialize(), the full data structure is constructed.
     # We need this, because the construction of the equation requires information from
@@ -98,7 +98,7 @@ struct Equation <: AbstractEquation
     eval_RJ::Function     # Function evaluating the residual and its gradient
 end
 
-# 
+#
 # dummy constructor - just stores the expresstion without any processing
 Equation(expr::ExtExpr) = Equation("", EqnFlags(), expr, Expr(:block), LittleDict(), LittleDict(), LittleDict(), eqnnotready, eqnnotready)
 

--- a/src/linearize.jl
+++ b/src/linearize.jl
@@ -84,12 +84,12 @@ linearizationerror(args...) = modelerror(LinearizationError, args...)
 export linearize!
 function linearize!(model::Model;
     # Idea:
-    # 
-    # We compute the residual and the Jacobian matrix at the steady state and 
+    #
+    # We compute the residual and the Jacobian matrix at the steady state and
     # store them in the model evaluation data. We store that into our new
     # linearized model evaluation data, which we place in the Model instance.
-    # When we evaluate the linearized model residual, all we need to do is multiply 
-    # the stored steady state Jacobian by the deviation of the given point from 
+    # When we evaluate the linearized model residual, all we need to do is multiply
+    # the stored steady state Jacobian by the deviation of the given point from
     # the steady state and add the stored steady state residual.
 
     sstate::SteadyStateData=model.sstate,
@@ -133,7 +133,7 @@ Create a new model that is the linear approximation of the given model about its
 
 ### Keyword arguments
   * `sstate` - linearize about the provided steady state solution
-  * `deviation`::Bool - whether or not the linearized model will tread data passed 
+  * `deviation`::Bool - whether or not the linearized model will tread data passed
 to is as deviation from the steady state
 
 See also: [`linearize!`](@ref) and [`with_linearized`](@ref)
@@ -144,13 +144,13 @@ export with_linearized
 """
     with_linearized(F::Function, model::Model; <arguments>)
 
-Apply the given function on a new model that is the linear approximation 
+Apply the given function on a new model that is the linear approximation
 of the given model about its steady state.  This is meant to be used
 with the `do` syntax, as in the example below.
 
 ### Keyword arguments
   * `sstate` - linearize about the provided steady state solution
-  * `deviation`::Bool - whether or not the linearized model will tread data passed 
+  * `deviation`::Bool - whether or not the linearized model will tread data passed
 to is as deviation from the steady state
 
 See also: [`linearize!`](@ref) and [`with_linearized`](@ref)
@@ -169,7 +169,7 @@ function with_linearized(F::Function, model::Model; kwargs...)
     variant = model.options.variant
     lmed = get(model.evaldata, :linearize, nothing)
     ret = try
-        # linearize 
+        # linearize
         linearize!(model; kwargs...)
         # do what we have to do
         F(model)

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -77,7 +77,7 @@ hint(::ModelNotInitError) = "Call `@initialize model` first."
 """
     struct NotImplementedError <: ModelErrorBase
 
-Specific error type used when a feature is planned but not yet implemented. 
+Specific error type used when a feature is planned but not yet implemented.
 """
 struct NotImplementedError <: ModelErrorBase
     descr

--- a/src/model.jl
+++ b/src/model.jl
@@ -64,7 +64,7 @@ mutable struct Model <: AbstractModel
     shocks::Vector{ModelVariable}
     # transition equations
     equations::Vector{Equation}
-    # parameters 
+    # parameters
     parameters::Parameters
     # auto-exogenize mapping of variables and shocks
     autoexogenize::Dict{Symbol,Symbol}
@@ -79,7 +79,7 @@ mutable struct Model <: AbstractModel
     evaldata::LittleDict{Symbol,AbstractModelEvaluationData}
     # data slot to be used by the solver (in StateSpaceEcon)
     solverdata::LittleDict{Symbol,Any}
-    # 
+    #
     # constructor of an empty model
     Model(opts::Options) = new(merge(defaultoptions, opts),
         ModelFlags(), SteadyStateData(), false, [], [], [], Parameters(), Dict(), 0, 0, [], [],
@@ -362,7 +362,7 @@ end
 ################################################################
 # The macros used in the model definition.
 
-# Note: These macros simply store the information into the corresponding 
+# Note: These macros simply store the information into the corresponding
 # arrays within the model instance. The actual processing is done in @initialize
 
 export @variables, @logvariables, @neglogvariables, @steadyvariables, @exogenous, @shocks
@@ -376,7 +376,7 @@ export @parameters, @equations, @autoshocks, @autoexogenize
         ...
     end
 
-Declare the names of variables in the model. 
+Declare the names of variables in the model.
 
 In the `begin-end` version the variable names can be preceeded by a description
 (like a docstring) and flags like `@log`, `@steady`, `@exog`, etc. See
@@ -437,7 +437,7 @@ end
 """
     @exogenous
 
-Like [`@variables`](@ref), but the names declared with `@exogenous` are 
+Like [`@variables`](@ref), but the names declared with `@exogenous` are
 exogenous.
 """
 macro exogenous(model, block::Expr)
@@ -451,7 +451,7 @@ end
 """
     @shocks
 
-Like [`@variables`](@ref), but the names declared with `@shocks` are 
+Like [`@variables`](@ref), but the names declared with `@shocks` are
 shocks.
 """
 macro shocks(model, block::Expr)
@@ -487,7 +487,7 @@ end
         ...
     end
 
-Declare and define the model parameters. 
+Declare and define the model parameters.
 
 The parameters must have values. Provide the information in a series of
 assignment statements wrapped inside a begin-end block. Use `@link` and `@alias`
@@ -595,7 +595,7 @@ function process_equation(model::Model, expr::Expr;
     flags=EqnFlags(),
     doc="")
 
-    # a list of all known time series 
+    # a list of all known time series
     allvars = model.allvars
 
     # keep track of model parameters used in expression
@@ -629,12 +629,12 @@ function process_equation(model::Model, expr::Expr;
 
     ###################
     #    process(expr)
-    # 
+    #
     # Process the expression, performing various tasks.
     #  + keep track of mentions of parameters and variables (including shocks)
     #  + remove line numbers from expression, but keep track so we can insert it into the residual functions
     #  + for each time-referenece of variable, create a dummy symbol that will be used in constructing the residual functions
-    # 
+    #
     # leave numbers alone
     process(num::Number) = num
     # store line number and discard it from the expression
@@ -666,7 +666,7 @@ function process_equation(model::Model, expr::Expr;
     end
     # Main version of process() - it's recursive
     function process(ex::Expr)
-        # is this a docstring? 
+        # is this a docstring?
         if ex.head == :macrocall && ex.args[1] == doc_macro
             push!(source, ex.args[2])
             doc *= ex.args[3]
@@ -757,9 +757,9 @@ function process_equation(model::Model, expr::Expr;
 
     ##################
     #    make_residual_expression(expr)
-    # 
+    #
     # Convert a processed equation into an expression that evaluates the residual.
-    # 
+    #
     #  + each mention of a time-reference is replaced with its symbol
     make_residual_expression(any) = any
     make_residual_expression(name::Symbol) = haskey(model.parameters, name) ? prefs[name] : name
@@ -844,14 +844,14 @@ function add_equation!(model::Model, expr::Expr; modelmodule::Module=moduleof(mo
     done_equalsign = Ref(false)
 
     ##################################
-    # We preprocess() the expression looking for substitutions. 
+    # We preprocess() the expression looking for substitutions.
     # If we find one, we create an auxiliary variable and equation.
     # We also keep track of line number, so we can label the aux equation as
     # defined on the same line.
     # We also look for doc string and flags (@log, @lin)
-    # 
-    # We make sure to make a copy of the expression and not to overwrite it. 
-    # 
+    #
+    # We make sure to make a copy of the expression and not to overwrite it.
+    #
     preprocess(any) = any
     function preprocess(line::LineNumberNode)
         push!(source, line)
@@ -897,10 +897,10 @@ function add_equation!(model::Model, expr::Expr; modelmodule::Module=moduleof(mo
         if getoption!(model; substitutions=true)
             local arg
             matched = @capture(ret, log(arg_))
-            # is it log(arg) 
+            # is it log(arg)
             if matched && isa(arg, Expr)
                 local var1, var2, ind1, ind2
-                # is it log(x[t]) ? 
+                # is it log(x[t]) ?
                 matched = @capture(arg, var1_[ind1_])
                 if matched
                     mv = model.:($var1)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -93,13 +93,13 @@ macro parameters()
 end
 
 # To deepcopy() Parameters, we make a new Ref to the same module and a deepcopy of contents.
-function Base.deepcopy_internal(p::Parameters, stackdict::IdDict) 
+function Base.deepcopy_internal(p::Parameters, stackdict::IdDict)
     if haskey(stackdict, p)
         return stackdict[p]::typeof(p)
     end
     p_copy = Parameters(
-        Ref(p.mod[]), 
-        Base.deepcopy_internal(p.contents, stackdict), 
+        Ref(p.mod[]),
+        Base.deepcopy_internal(p.contents, stackdict),
         Ref(p.rev[])
     )
     stackdict[p] = p_copy
@@ -230,7 +230,7 @@ end
 
 Evaluate the given expression in the context of the given parameters `params`.
 
-If `what` is a `ModelParam`, its current value is returned. If it's a link and 
+If `what` is a `ModelParam`, its current value is returned. If it's a link and
 there's a chance it might be out of date, call [`update_links!`](@ref).
 
 If `what` is a Symbol or an Expr, all mentions of parameter names are
@@ -256,8 +256,8 @@ peval(m::AbstractModel, what) = peval(parameters(m), what)
 """
     @peval params what
 
-Evaluate the expression `what` within the context of the 
-given set of parameters 
+Evaluate the expression `what` within the context of the
+given set of parameters
 """
 macro peval(par, what)
     qwhat = Meta.quot(what)
@@ -408,7 +408,7 @@ end
 
 Assign values to model parameters. New parameters can be given as key-value pairs
 in the function call, or in a collection, such as a `Dict`, for example.
-    
+
 Individual parameters can be assigned directly to the `model` using
 dot notation. This function should be more convenient when all parameters values
 are loaded from a file and available in a dictionary or some other key-value

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -44,7 +44,7 @@ struct SteadyStateVariable{DATA<:AbstractVector{Float64},MASK<:AbstractVector{Bo
     index::Int
     # A view in the SteadyStateData.values location for this variable
     data::DATA
-    # A view into the mask array 
+    # A view into the mask array
     mask::MASK
 end
 
@@ -98,7 +98,7 @@ function Base.getindex(v::SteadyStateVariable, t; ref=first(t))
 end
 
 #################################
-# pretty printing 
+# pretty printing
 
 
 # Return a 5-tuple with the number of characters for the name, and the alignment
@@ -295,7 +295,7 @@ Base.getindex(ssd::SteadyStateData, sym::AbstractString) = getproperty(ssd, Symb
 @inline ss_symbol(ssd::SteadyStateData, vi::Int) = Symbol("#", ssd.vars[(1+vi)÷2].name.name, "#", (vi % 2 == 1) ? :lvl : :slp, "#")
 
 #########################
-# 
+#
 
 export printsstate
 
@@ -328,14 +328,14 @@ printsstate(model::AbstractModel) = printsstate(Base.stdout, model)
 #   in the steady state equation, we assume that the variable y_ss
 #   follows a linear motion expressed as y_ss[t] = y_ss#lvl + t * y_ss#slp
 #   where y_ss#lvl and y_ss#slp are two unknowns we solve for.
-# 
+#
 #   The dynamic equation has mentions of lags and leads. We replace those
 #   with the above expression.
-# 
+#
 #   Since we have two parameters to determine, we need two steady state equations
 #   from each dynamic equation. We get this by writing the dynamic equation at
 #   two different values of `t` - 0 and another one we call `shift`.
-# 
+#
 #   Shift is a an option in the model object, which the user can set to any integer
 #   other than 0. The default is 10.
 
@@ -519,14 +519,14 @@ function setss!(model::AbstractModel, expr::Expr; type::Symbol, modelmodule::Mod
     end
     ###############################################
     #     ssprocess(val)
-    # 
+    #
     # Process the given value to extract information about mentioned parameters and variables.
     # This function has the side effect of populating the vectors
     # `vinds`, `vsyms`, `val_params` and `source`
-    # 
+    #
     # Algorithm is recursive over the given expression. The bottom of the recursion is the
     # processing of a `Number`, a `Symbol`, (or a `LineNumberNode`).
-    # 
+    #
     # we will store indices
     local vinds = Int64[]
     local vsyms = Symbol[]
@@ -590,12 +590,12 @@ function setss!(model::AbstractModel, expr::Expr; type::Symbol, modelmodule::Mod
     end
     # end of ssprocess() definition
     ###############################################
-    # 
+    #
     lhs, rhs = expr.args
     lhs = ssprocess(lhs)
     rhs = ssprocess(rhs)
     expr.args .= MacroTools.unblock.(expr.args)
-    # 
+    #
     nargs = length(vinds)
     # In case there's no source information, add a dummy one
     push!(source, LineNumberNode(0))
@@ -712,7 +712,7 @@ issssolved(ss::SteadyStateData) = all(ss.mask)
     assign_sstate!(model; var = value, ...)
 
 Assign a steady state solution from the given collection of name=>value pairs
-into the given model. 
+into the given model.
 
 In each pair, the value can be a number in which case it is assigned as the
 level and the slope is set to 0. The value can also be a `Tuple` or a `Vector`
@@ -772,7 +772,7 @@ export export_sstate
 """
     export_sstate!(container, model)
 
-Fill the given container with the steady state solution stored in the 
+Fill the given container with the steady state solution stored in the
 given model. The value for each variable will be a number, if the variable has
 zero slope, or else a named tuple of the form `(level = NUM, slope=NUM)`.
 """

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -24,10 +24,10 @@ respects, but also holds meta-information about the variable, such as doc
 string, the variable type, transformation, steady state behaviour.
 
 Variable types include
- * `:var` - a regular variable is endogenous by default, but can be exogenized. 
+ * `:var` - a regular variable is endogenous by default, but can be exogenized.
  * `:shock` - a shock variable is exogenous by default, but can be endogenized.
    Steady state is 0.
- * `:exog` - an exogenous variable is always exogenous. 
+ * `:exog` - an exogenous variable is always exogenous.
 
  These can be declared with [`@variables`](@ref), [`@shocks`](@ref), and
  [`@exogenous`](@ref) blocks. You can also use `@exog` within an
@@ -40,7 +40,7 @@ Variable types include
    positive. Internally the solver work with the logarithm of the variable. in
    steady state these variables exhibit exponential growth (the log variable
    grows linearly).
-* `:neglog` - same as `:log` but for variables that are strictly negative. 
+* `:neglog` - same as `:log` but for variables that are strictly negative.
 
 These can be declared with [`@logvariables`](@ref), [`@neglogvariables`](@ref),
 `@log`, `@neglog`.
@@ -51,11 +51,11 @@ Steady state behaviours include
 * `:growth` - these variables have constant slope in steady state and final
   conditions. The meaning of "slope" changes depending on the transformation.
   For `:log` and `:neglog` variables this is the growth rate, while for `:none`
-  variables it is the usual slope of linear growth. 
+  variables it is the usual slope of linear growth.
 
 Shock variables are always `:const` while regular variables are assumed
 `:growth`. They can be declared `:const` using `@steady`.
- 
+
 """
 struct ModelVariable
     doc::String
@@ -79,7 +79,7 @@ function Base.getproperty(v::ModelVariable, s::Symbol)
             return vt
         end
         tt = getfield(v, :tr_type)
-        if tt !== :none 
+        if tt !== :none
             return tt
         end
         if getfield(v, :ss_type) === :const

--- a/test/auxsubs.jl
+++ b/test/auxsubs.jl
@@ -39,7 +39,7 @@ end
     log(lx[t]) - log(lx[t - 1]) = log(0.0 + 1.0)
 end
 
-@initialize model 
+@initialize model
 
 end"""))
     m = ASUBS.model

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -598,34 +598,34 @@ end
     @equations mod begin
         x[t-1] = sx[t+1]
         @lag(x[t]) = @lag(sx[t+2])
-        # 
+        #
         x[t-1] + a = sx[t+1] + 3
         @lag(x[t] + a) = @lag(sx[t+2] + 3)
-        # 
+        #
         x[t-2] = sx[t]
         @lag(x[t], 2) = @lead(sx[t-2], 2)
-        # 
+        #
         x[t] - x[t-1] = x[t+1] - x[t] + sx[t]
         @d(x[t]) = @d(x[t+1]) + sx[t]
-        # 
+        #
         (x[t] - x[t+1]) - (x[t-1] - x[t]) = sx[t]
         @d(x[t] - x[t+1]) = sx[t]
-        # 
+        #
         x[t] - x[t-2] = sx[t]
         @d(x[t], 0, 2) = sx[t]
-        # 
+        #
         x[t] - 2x[t-1] + x[t-2] = sx[t]
         @d(x[t], 2) = sx[t]
-        # 
+        #
         x[t] - x[t-1] - x[t-2] + x[t-3] = sx[t]
         @d(x[t], 1, 2) = sx[t]
-        # 
+        #
         log(x[t] - x[t-2]) - log(x[t-1] - x[t-3]) = sx[t]
         @dlog(@d(x[t], 0, 2)) = sx[t]
-        # 
+        #
         (x[t] + 0.3x[t+2]) + (x[t-1] + 0.3x[t+1]) + (x[t-2] + 0.3x[t]) = 0
         @movsum(x[t] + 0.3x[t+2], 3) = 0
-        # 
+        #
         ((x[t] + 0.3x[t+2]) + (x[t-1] + 0.3x[t+1]) + (x[t-2] + 0.3x[t])) / 3 = 0
         @movav(x[t] + 0.3x[t+2], 3) = 0
     end
@@ -927,7 +927,7 @@ end
     end
     @test length(out) == 3
     @test length(split(out[end], "=")) == 2
-    # 
+    #
     @test propertynames(ss) == tuple(m.allvars...)
     @test ss.pinf.level == ss.pinf.data[1]
     @test ss.pinf.slope == ss.pinf.data[2]
@@ -1042,7 +1042,7 @@ end
             log(x[t]) = lx[t] + s2[t+1]
         end
         @initialize m
-        # 
+        #
         @test nvariables(m) == 2
         @test nshocks(m) == 2
         @test nequations(m) == 2
@@ -1050,7 +1050,7 @@ end
         @test neqns(ss) == 4
         eq1, eq2, eq3, eq4 = ss.equations
         @test length(ss.values) == 2 * length(m.allvars)
-        # 
+        #
         # test with eq1
         ss.lx.data .= [1.5, 0.2]
         ss.x.data .= [0.0, 0.2]


### PR DESCRIPTION
This PR removes trailing whitespace on all source files. 

The main drawback is that the git blame gets polluted and some of the whitespace is on function lines and lines which have been commented out.

For this reason we may want to not merge this PR.