### PR TITLE
tighten up types in the `params` for `EquationEvaluator`

### DIFF
--- a/src/ModelBaseEcon.jl
+++ b/src/ModelBaseEcon.jl
@@ -8,7 +8,7 @@
 """
     ModelBaseEcon
 
-This package is part of the StateSpaceEcon ecosystem. 
+This package is part of the StateSpaceEcon ecosystem.
 It provides the basic elements needed for model definition.
 StateSpaceEcon works with model objects defined with ModelBaseEcon.
 """
@@ -44,6 +44,7 @@ include("metafuncs.jl")
 include("model.jl")
 include("export_model.jl")
 include("linearize.jl")
+include("precompile.jl")
 
 """
     @using_example name

--- a/src/ModelBaseEcon.jl
+++ b/src/ModelBaseEcon.jl
@@ -21,6 +21,15 @@ using DiffResults
 using ForwardDiff
 using Printf
 
+# Note: The full type specification for `LittleDict` has 4 parameters.
+# Specifying only the first two in a struct as:
+# struct S
+#    a::LittleDict{Symbol, Int}
+# end
+# will be treated by Julia as a non-concrete field.
+# Therefore, define a small helper typealias to use in structs:
+const LittleDictVec{K,V} = LittleDict{K,V,Vector{K},Vector{V}}
+
 # The Timer submodule
 include("Timer.jl")
 using .Timer

--- a/src/equation.jl
+++ b/src/equation.jl
@@ -87,11 +87,11 @@ struct Equation <: AbstractEquation
     """
     resid::Expr     # residual expression
     "references to time series variables"
-    tsrefs::LittleDict{Tuple{ModelSymbol, Int}, Symbol}
+    tsrefs::LittleDictVec{Tuple{ModelSymbol, Int}, Symbol}
     "references to steady states of variables"
-    ssrefs::LittleDict{ModelSymbol, Symbol}
+    ssrefs::LittleDictVec{ModelSymbol, Symbol}
     "references to parameter values"
-    prefs::LittleDict{Symbol, Symbol}
+    prefs::LittleDictVec{Symbol, Symbol}
     "A callable (function) evaluating the residual. Argument is a vector of Float64 same lenght as `vinds`"
     eval_resid::Function  # function evaluating the residual
     "A callable (function) evaluating the (residual, gradient) pair. Argument is a vector of Float64 same lenght as `vinds`"
@@ -100,7 +100,12 @@ end
 
 # 
 # dummy constructor - just stores the expresstion without any processing
-Equation(expr::ExtExpr) = Equation("", EqnFlags(), expr, Expr(:block), LittleDict(), LittleDict(), LittleDict(), eqnnotready, eqnnotready)
+Equation(expr::ExtExpr) = Equation("", EqnFlags(), expr, Expr(:block), 
+                                    LittleDict{Tuple{ModelSymbol, Int}, Symbol}(),
+                                    LittleDict{ModelSymbol, Symbol}(), 
+                                    LittleDict{Symbol, Symbol}(),
+                                    eqnnotready, eqnnotready)
+
 
 function Base.getproperty(eqn::Equation, sym::Symbol)
     if sym == :maxlag
@@ -116,4 +121,3 @@ end
 
 # Allows us to pass a Number of a Symbol or a raw Expr to calls where Equation is expected.
 Base.convert(::Type{Equation}, e::ExtExpr) = Equation(e)
-

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -104,7 +104,7 @@ function makefuncs(expr, tssyms, sssyms, psyms, mod)
             $expr
         end
         const $fn1 = EquationEvaluator{$(QuoteNode(fn1))}(UInt(0),
-            $(@__MODULE__).LittleDict(Symbol[$(QuoteNode.(psyms)...)], fill(nothing, $(length(psyms)))))
+            $(@__MODULE__).LittleDict(Symbol[$(QuoteNode.(psyms)...)], fill!(Vector{Any}(undef, $(length(psyms))), nothing)))
         const $fn2 = EquationGradient($FunctionWrapper($fn1), $nargs, Val($chunk))
         $(@__MODULE__).precompilefuncs($fn1, $fn2, Val($chunk))
         ($fn1, $fn2)
@@ -134,7 +134,7 @@ function initfuncs(mod::Module)
         mod.eval(quote
             struct EquationEvaluator{FN} <: Function
                 rev::Ref{UInt}
-                params::$(@__MODULE__).LittleDict{Symbol,Any}
+                params::$(@__MODULE__).LittleDictVec{Symbol,Any}
             end
             struct EquationGradient{DR,CFG} <: Function
                 fn1::Function

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -104,7 +104,7 @@ function makefuncs(expr, tssyms, sssyms, psyms, mod)
             $expr
         end
         const $fn1 = EquationEvaluator{$(QuoteNode(fn1))}(UInt(0),
-            $(@__MODULE__).LittleDict(Symbol[$(QuoteNode.(psyms)...)], fill!(Vector{Any}(undef, $(length(psyms))), nothing)))
+            $(@__MODULE__).LittleDict(Symbol[$(QuoteNode.(psyms)...)], fill!(Vector{Union{Int, Float64, Vector{Float64}}}(undef, $(length(psyms))), Float64[])))
         const $fn2 = EquationGradient($FunctionWrapper($fn1), $nargs, Val($chunk))
         $(@__MODULE__).precompilefuncs($fn1, $fn2, Val($chunk))
         ($fn1, $fn2)
@@ -134,7 +134,7 @@ function initfuncs(mod::Module)
         mod.eval(quote
             struct EquationEvaluator{FN} <: Function
                 rev::Ref{UInt}
-                params::$(@__MODULE__).LittleDictVec{Symbol,Any}
+                params::$(@__MODULE__).LittleDictVec{Symbol,Union{Int, Float64, Vector{Float64}}}
             end
             struct EquationGradient{DR,CFG} <: Function
                 fn1::Function

--- a/src/metafuncs.jl
+++ b/src/metafuncs.jl
@@ -110,7 +110,7 @@ For example: `at_movsum(x[t], 3) = x[t] + x[t-1] + x[t-2]`.
 See also [`at_lag`](@ref).
 """
 at_movsum(expr::Expr, n::Integer) = MacroTools.unblock(
-    Expr(:call, :+, expr, (at_lag(expr, i) for i = 1:n-1)...)
+    split_nargs(Expr(:call, :+, expr, (at_lag(expr, i) for i = 1:n-1)...))
 )
 
 """
@@ -132,10 +132,10 @@ For example: `at_movsumew(x[t], 3, 0.7) = x[t] + 0.7*x[t-1] + 0.7^2x[t-2]`
 See also [`at_movavew`](@ref)
 """
 at_movsumew(expr::Expr, n::Integer, r) =
-    MacroTools.unblock(Expr(:call, :+, expr, (Expr(:call, :*, :(($r)^($i)), at_lag(expr, i)) for i = 1:n-1)...))
+    MacroTools.unblock(split_nargs(Expr(:call, :+, expr, (Expr(:call, :*, :(($r)^($i)), at_lag(expr, i)) for i = 1:n-1)...)))
 at_movsumew(expr::Expr, n::Integer, r::Real) =
     isapprox(r, 1.0) ? at_movsum(expr, n) :
-    MacroTools.unblock(Expr(:call, :+, expr, (Expr(:call, :*, r^i, at_lag(expr, i)) for i = 1:n-1)...))
+    MacroTools.unblock(split_nargs(Expr(:call, :+, expr, (Expr(:call, :*, r^i, at_lag(expr, i)) for i = 1:n-1)...)))
 
 """
     at_movavew(expr, n, r)
@@ -165,4 +165,3 @@ for sym in (:lag, :lead, :d, :dlog, :movsum, :movav, :movsumew, :movavew)
     end
     eval(qq)
 end
-

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,41 @@
+
+"""
+    precompilefuncs(N::Int)
+
+Pre-compiles functions used by models for a `ForwardDiff.Dual` numbers
+with chunk size `N`.
+
+!!! warning
+    Internal function. Do not call directly
+
+"""
+function precompile_funcs(N::Int)
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+
+    tag = ModelBaseEconTag
+    dual = ForwardDiff.Dual{tag,Float64,N}
+    duals = Vector{dual}
+    cfg = ForwardDiff.GradientConfig{tag,Float64,N,duals}
+    mdr = DiffResults.MutableDiffResult{1,Float64,Tuple{Vector{Float64}}}
+
+    for pred in Symbol[:isinf, :isnan, :isfinite, :iseven, :isodd, :isreal, :isinteger, :-, :+, :log, :exp]
+        pred ∈ (:iseven, :isodd) || precompile(getfield(Base, pred), (Float64,)) || error("precompile")
+        precompile(getfield(Base, pred), (dual,)) || error("precompile")
+    end
+
+    for pred in Symbol[:isequal, :isless, :<, :>, :(==), :(!=), :(<=), :(>=), :+, :-, :*, :/, :^]
+        precompile(getfield(Base, pred), (Float64, Float64)) || error("precompile")
+        precompile(getfield(Base, pred), (dual, Float64)) || error("precompile")
+        precompile(getfield(Base, pred), (Float64, dual)) || error("precompile")
+        precompile(getfield(Base, pred), (dual, dual)) || error("precompile")
+    end
+
+    precompile(ForwardDiff.extract_gradient!, (Type{tag}, mdr, dual)) || error("precompile")
+    precompile(ForwardDiff.vector_mode_gradient!, (mdr, FunctionWrapper, Vector{Float64}, cfg)) || error("precompile")
+
+    return nothing
+end
+
+for i in 1:MAX_CHUNK_SIZE
+    precompile_funcs(i)
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -9,7 +9,7 @@ with chunk size `N`.
     Internal function. Do not call directly
 
 """
-function precompile_funcs(N::Int)
+function precompile_dual_funcs(N::Int)
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
 
     tag = ModelBaseEconTag
@@ -32,10 +32,21 @@ function precompile_funcs(N::Int)
 
     precompile(ForwardDiff.extract_gradient!, (Type{tag}, mdr, dual)) || error("precompile")
     precompile(ForwardDiff.vector_mode_gradient!, (mdr, FunctionWrapper, Vector{Float64}, cfg)) || error("precompile")
+    precompile(ForwardDiff.gradient!, (DiffResults.MutableDiffResult{1, Float64, Tuple{Vector{Float64}}},
+                                       FunctionWrapper, Vector{Float64}, ForwardDiff.GradientConfig{ModelBaseEconTag, Float64, N, Vector{ForwardDiff.Dual{ModelBaseEconTag, Float64, N}}})) || error("precompile")
 
     return nothing
 end
 
 for i in 1:MAX_CHUNK_SIZE
-    precompile_funcs(i)
+    precompile_dual_funcs(i)
 end
+
+function precompile_other()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    precompile(Tuple{typeof(eval_RJ), Matrix{Float64}, Model}) || error("precompile")
+    precompile(Tuple{typeof(_update_eqn_params!), Function, Parameters{ModelParam}}) || error("precompile")
+    precompile(Tuple{typeof(eval_RJ), Matrix{Float64}, ModelEvaluationData{Equation, Vector{CartesianIndex{2}}, DynEqnEvalData0}}) || error("precompile")
+end
+
+precompile_other()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -473,10 +473,10 @@ end
     @test ModelBaseEcon.at_lag(:(x[t]), 0) == :(x[t])
     @test_throws ErrorException ModelBaseEcon.at_d(:(x[t]), 0, -1)
     @test ModelBaseEcon.at_d(:(x[t]), 3, 0) == :(((x[t] - 3 * x[t-1]) + 3 * x[t-2]) - x[t-3])
-    @test ModelBaseEcon.at_movsumew(:(x[t]), 3, 2.0) == :(x[t] + 2.0 * x[t-1] + 4.0 * x[t-2])
-    @test ModelBaseEcon.at_movsumew(:(x[t]), 3, :y) == :(x[t] + y^1 * x[t-1] + y^2 * x[t-2])
-    @test ModelBaseEcon.at_movavew(:(x[t]), 3, 2.0) == :((x[t] + 2.0 * x[t-1] + 4.0 * x[t-2]) / 7.0)
-    @test ModelBaseEcon.at_movavew(:(x[t]), 3, :y) == :(((x[t] + y^1 * x[t-1] + y^2 * x[t-2]) * (1 - y)) / (1 - y^3))
+    @test ModelBaseEcon.at_movsumew(:(x[t]), 3, 2.0) == :(x[t] + (2.0 * x[t-1] + 4.0 * x[t-2]))
+    @test ModelBaseEcon.at_movsumew(:(x[t]), 3, :y) == :(x[t] + (y^1 * x[t-1] + y^2 * x[t-2]))
+    @test ModelBaseEcon.at_movavew(:(x[t]), 3, 2.0) == :((x[t] + (2.0 * x[t-1] + 4.0 * x[t-2])) / 7.0)
+    @test ModelBaseEcon.at_movavew(:(x[t]), 3, :y) == :(((x[t] + (y^1 * x[t-1] + y^2 * x[t-2])) * (1 - y)) / (1 - y^3))
 end
 module MetaTest
 using ModelBaseEcon
@@ -598,34 +598,34 @@ end
     @equations mod begin
         x[t-1] = sx[t+1]
         @lag(x[t]) = @lag(sx[t+2])
-        # 
+        #
         x[t-1] + a = sx[t+1] + 3
         @lag(x[t] + a) = @lag(sx[t+2] + 3)
-        # 
+        #
         x[t-2] = sx[t]
         @lag(x[t], 2) = @lead(sx[t-2], 2)
-        # 
+        #
         x[t] - x[t-1] = x[t+1] - x[t] + sx[t]
         @d(x[t]) = @d(x[t+1]) + sx[t]
-        # 
+        #
         (x[t] - x[t+1]) - (x[t-1] - x[t]) = sx[t]
         @d(x[t] - x[t+1]) = sx[t]
-        # 
+        #
         x[t] - x[t-2] = sx[t]
         @d(x[t], 0, 2) = sx[t]
-        # 
+        #
         x[t] - 2x[t-1] + x[t-2] = sx[t]
         @d(x[t], 2) = sx[t]
-        # 
+        #
         x[t] - x[t-1] - x[t-2] + x[t-3] = sx[t]
         @d(x[t], 1, 2) = sx[t]
-        # 
+        #
         log(x[t] - x[t-2]) - log(x[t-1] - x[t-3]) = sx[t]
         @dlog(@d(x[t], 0, 2)) = sx[t]
-        # 
+        #
         (x[t] + 0.3x[t+2]) + (x[t-1] + 0.3x[t+1]) + (x[t-2] + 0.3x[t]) = 0
         @movsum(x[t] + 0.3x[t+2], 3) = 0
-        # 
+        #
         ((x[t] + 0.3x[t+2]) + (x[t-1] + 0.3x[t+1]) + (x[t-2] + 0.3x[t])) / 3 = 0
         @movav(x[t] + 0.3x[t+2], 3) = 0
     end
@@ -902,7 +902,7 @@ end
     end
     @test length(out) == 3
     @test length(split(out[end], "=")) == 2
-    # 
+    #
     @test propertynames(ss) == tuple(m.allvars...)
     @test ss.pinf.level == ss.pinf.data[1]
     @test ss.pinf.slope == ss.pinf.data[2]
@@ -1017,7 +1017,7 @@ end
             log(x[t]) = lx[t] + s2[t+1]
         end
         @initialize m
-        # 
+        #
         @test nvariables(m) == 2
         @test nshocks(m) == 2
         @test nequations(m) == 2
@@ -1025,7 +1025,7 @@ end
         @test neqns(ss) == 4
         eq1, eq2, eq3, eq4 = ss.equations
         @test length(ss.values) == 2 * length(m.allvars)
-        # 
+        #
         # test with eq1
         ss.lx.data .= [1.5, 0.2]
         ss.x.data .= [0.0, 0.2]


### PR DESCRIPTION
The current parameters have a declared type of `Any` in the struct which leads to bad performance.
For example, loading the FRB-US model and looking at code_warntype we can see:

```julia
julia> @code_warntype FRBUS_VAR.resid_99(rand(3))
MethodInstance for (::FRBUS_VAR.EquationEvaluator{:resid_99})(::Vector{Float64})
  from (ee::FRBUS_VAR.EquationEvaluator{:resid_99})(x::Vector{<:Real}) @ FRBUS_VAR ~/BoC/dev/ModelBaseEcon/src/evaluation.jl:115
Arguments
  ee::FRBUS_VAR.EquationEvaluator{:resid_99}
  x#390::Vector{Float64}
Locals
  @_3::Union{}
  @_4::Int64
  y_qec::Any
  0#@_6::Float64
  zyhp#0#::Float64
  zyht#0#::Float64
  0#@_9::Float64
  0#@_10::Float64
  qec#0#::Float64
Body::Any
...
│   %19 = Base.getproperty(ee, :params)::OrderedCollections.LittleDict{Symbol, Any}
│   %20 = FRBUS_VAR.values(%19)::Base.ValueIterator
│   %21 = Base.indexed_iterate(%20, 1)::Tuple{Any, Any}
│         (y_qec = Core.getfield(%21, 1))
│   %23 = (exp)(qec#0#)::Float64
│   %24 = FRBUS_VAR.log(%23)::Float64
│   %25 = (%24 - 0#@_10)::Float64
│   %26 = Base.getindex(y_qec, 1)::Any
│   %27 = Base.getindex(y_qec, 2)::Any
│   %28 = (%27 * 0#@_9)::Any
│   %29 = Base.getindex(y_qec, 3)::Any
│   %30 = (exp)(zyht#0#)::Float64
│   %31 = FRBUS_VAR.log(%30)::Float64
│   %32 = (%29 * %31)::Any
│   %33 = Base.getindex(y_qec, 2)::Any
│   %34 = (1 - %33)::Any
│   %35 = Base.getindex(y_qec, 3)::Any
│   %36 = (%34 - %35)::Any
│   %37 = Base.getindex(y_qec, 4)::Any
│   %38 = (%36 - %37)::Any
│   %39 = (exp)(zyhp#0#)::Float64
│   %40 = FRBUS_VAR.log(%39)::Float64
│   %41 = (%38 * %40)::Any
│   %42 = Base.getindex(y_qec, 4)::Any
│   %43 = (%42 * 0#@_6)::Any
│   %44 = (%26 + %28 + %32 + %41 + %43)::Any
│   %45 = (%25 - %44)::Any
└──       return %45
```

where there are a lot of `Any`


This PR tightens up the allowed types in the `EquationEvaluator` for the `params` to allow stronger inference and union splitting.

Running the follwoing benchmark:

```julia
unique!(push!(LOAD_PATH, realpath("./models")))
using ModelBaseEcon
using FRBUS_VAR

m = FRBUS_VAR.model
nrows = 1 + m.maxlag + m.maxlead
ncols = length(m.allvars)
pt = zeros(nrows, ncols);
using BenchmarkTools
https://github.com/Btime @eval eval_RJ(pt, m);
```

The time goes from

`544.104 μs (22094 allocations: 860.48 KiB)`
to
`326.093 μs (5581 allocations: 228.33 KiB)`

The drawback of course is that only these type of parameters can be used in a model.
If a restriction to the parameters is ok, something like this can be done.
If the parameters truly need to be able to take on any type, we need to rethink a little bit in using a single
callable struct for all equations.