### PR TITLE
use a function barrier for evaluating equations with parameters 

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -816,8 +816,9 @@ function process_equation(model::Model, expr::Expr;
     sssyms = values(ssrefs)
     psyms = values(prefs)
     funcs_expr = makefuncs(residual, tssyms, sssyms, psyms, modelmodule)
-    resid, RJ = modelmodule.eval(funcs_expr)
+    resid, RJ, resid_param, chunk = modelmodule.eval(funcs_expr)
     _update_eqn_params!(resid, model.parameters)
+    modelmodule.eval(:($(@__MODULE__).precompilefuncs($resid, $RJ, $resid_param, $chunk)))
     tsrefs′ = LittleDict{Tuple{ModelSymbol,Int},Symbol}()
     for ((modsym, i), sym) in tsrefs
         tsrefs′[(ModelSymbol(modsym), i)] = sym


### PR DESCRIPTION
In https://github.com/bankofcanada/ModelBaseEcon.jl/pull/48 it was described how the non typed `params` dictionary in `EquationEvaluator` leads to type instabilities and bad performance.
The suggestion in that PR was to limit the "type space" that parameters can take.
It is however not clear what type space this should be since users can in theory define arbitrary types in their model.

This PR thus takes a different approach where equations involving parameters gets an extra function where that function has the type parameters as arguments.
The tradeoff then is the cost of a dynamic dispatch to the extra function vs having things be well typed inside that function.
Julia's dynamic dispatch is quite fast and from benchmarks this seems to be a good gain.

Running the benchmark

```julia
unique!(push!(LOAD_PATH, realpath("./models"))) # hide
using ModelBaseEcon
using FRBUS_VAR
m = FRBUS_VAR.model
nrows = 1 + m.maxlag + m.maxlead
ncols = length(m.allvars)
pt = zeros(nrows, ncols);

@time @eval eval_RJ(pt, m);

using BenchmarkTools
@btime eval_RJ(pt, m);
```

We get before this commit:

```julia
0.061867 seconds (70.38 k allocations: 3.958 MiB, 87.67% compilation time)
600.875 μs (22059 allocations: 858.70 KiB)
```

and after it:

```julia
0.027602 seconds (34.27 k allocations: 2.109 MiB, 78.96% compilation time)
399.541 μs (6695 allocations: 262.45 KiB)
```

This shows that the time for the first call is virtually uneffected while the runtime of evaluating `eval_RJ` is significantly improved.

The approach in #48 had the following results:

```julia
0.025336 seconds (32.00 k allocations: 1.992 MiB, 78.75% compilation time)
342.084 μs (5546 allocations: 226.55 KiB)
```

which is a bit better than this PR but has the drawback of limiting the possible types for parameters while this PR does not lose any generality.