### PR TITLE
proof of concept, multithread `eval_RJ`

### DIFF
--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -365,7 +365,11 @@ function eval_RJ(point::Matrix{Float64}, med::ModelEvaluationData)
     neqns = length(med.alleqns)
     res = similar(med.R)
     jac = med.J
-    for (i, eqn, inds, ri, ed) in zip(1:neqns, med.alleqns, med.allinds, med.rowinds, med.eedata)
+    Threads.@threads for i in 1:neqns
+        eqn = med.alleqns[i]
+        inds = med.allinds[i]
+        ri = med.rowinds[i]
+        ed = med.eedata[i]
         _update_eqn_params!(eqn.eval_resid, med.params[])
         res[i], jac.nzval[ri] = eval_RJ(eqn, point[inds], ed)
     end
@@ -458,7 +462,11 @@ function eval_RJ(point::Matrix{Float64}, slmed::SelectiveLinearizationMED)
     neqns = length(med.alleqns)
     res = similar(med.R)
     jac = med.J
-    for (i, eqn, inds, ri, eed) in zip(1:neqns, med.alleqns, med.allinds, med.rowinds, slmed.eedata)
+    Threads.@threads for i in 1:neqns
+        eqn = med.alleqns[i]
+        inds = med.allinds[i]
+        ri = med.rowinds[i]
+        eed = slmed.eedata[i]
         islin(eqn) || _update_eqn_params!(eqn.eval_resid, med.params[])
         res[i], jac.nzval[ri] = eval_RJ(eqn, point[inds], eed)
     end


### PR DESCRIPTION
The evaluations of the residuals and Jacobians seem independent and it should therefore be possible to evaluate them in parallel. A simple use of the `Threads.@threads` loop construct gives:

baseline:

```julia
julia> @btime eval_RJ(pt, m);
  399.917 μs (6695 allocations: 262.45 KiB)
```

PR with `--threads=8` on an Mac M1 Pro:

```julia
julia> @btime eval_RJ(pt, m);
  106.875 μs (6743 allocations: 267.98 KiB)
```