### PR TITLE
prepend exported options with model.options.

### DIFF
--- a/src/export_model.jl
+++ b/src/export_model.jl
@@ -32,6 +32,9 @@ function export_model(model::Model, name::AbstractString, fio::IO)
     println(fio, "module ", name)
     println(fio)
     println(fio, "using ModelBaseEcon")
+    if :fctype ∈ keys(model.options)
+        println(fio, "using StateSpaceEcon")
+    end
     println(fio)
     println(fio, "const model = Model()")
     println(fio)
@@ -48,7 +51,7 @@ function export_model(model::Model, name::AbstractString, fio::IO)
     end
 
     println(fio, "# options")
-    _print_modified_options(model.options, defaultoptions, "model.")
+    _print_modified_options(model.options, defaultoptions, "model.options.")
     println(fio)
 
     println(fio, "# flags")


### PR DESCRIPTION
This PR includes two changes

1. Exported options now prepended with `model.options.` instead of simply `model.`. 
2. The exported model now uses the StateSpaceEcon package if there is a final conditions option set.

Note that the export of flags was not changed.