### PR TITLE
Add option to suppress unused varshks warning

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -1867,7 +1867,7 @@ function replace_in_expr(e::Expr, old::Model, new::Union{Symbol,Expr}, params::P
 end
 
 """
-    get_unused_symbols(model::Model; filter_nowarn=false)
+    get_unused_symbols(model::Model; filter_known_unused=false)
 
 Returns a dictionary with vectors of the unused variables, shocks, and parameters.
 
@@ -1875,7 +1875,7 @@ Keyword arguments:
 * filter_known_unused::Bool - When `true`, the results will exclude variables present in model.option.unused_varshks.
   The default is `false`.
 """
-function get_unused_symbols(model::Model; filter_known_unused=false)
+function get_unused_symbols(model::Model; filter_known_unused::Bool=false)
     eqmap = equation_map(model)
     unused = Dict(
         :variables => filter(x -> !haskey(eqmap, x), [x.name for x in model.variables]),

--- a/src/model.jl
+++ b/src/model.jl
@@ -1405,7 +1405,7 @@ function initialize!(model::Model, modelmodule::Module)
         # if dynss is true, then we need the steady state even for the standard MED
         nothing
     end
-    unused = get_unused_symbols(model)
+    unused = get_unused_symbols(model; filter_known_unused=true)
     if length(unused[:variables]) > 0
         @warn "Model contains unused variables: $(unused[:variables])"
     end
@@ -1458,7 +1458,7 @@ function reinitialize!(model::Model, modelmodule::Module=moduleof(model))
         # if dynss is true, then we need the steady state even for the standard MED
         nothing
     end
-    unused = get_unused_symbols(model)
+    unused = get_unused_symbols(model; filter_known_unused=true)
     if length(unused[:variables]) > 0
         @warn "Model contains unused variables: $(unused[:variables])"
     end
@@ -1867,17 +1867,26 @@ function replace_in_expr(e::Expr, old::Model, new::Union{Symbol,Expr}, params::P
 end
 
 """
-    get_unused_symbols(model::Model)
+    get_unused_symbols(model::Model; filter_nowarn=false)
 
 Returns a dictionary with vectors of the unused variables, shocks, and parameters.
+
+Keyword arguments:
+* filter_known_unused::Bool - When `true`, the results will exclude variables present in model.option.unused_varshks.
+  The default is `false`.
 """
-function get_unused_symbols(model::Model)
+function get_unused_symbols(model::Model; filter_known_unused=false)
     eqmap = equation_map(model)
     unused = Dict(
         :variables => filter(x -> !haskey(eqmap, x), [x.name for x in model.variables]),
         :shocks => filter(x -> !haskey(eqmap, x), [x.name for x in model.shocks]),
         :parameters => filter(x -> !haskey(eqmap, x), collect(keys(model.parameters)))
     )
+    if filter_known_unused && :unused_varshks ∈ model.options
+        for k in (:variables, :shocks)
+            unused[k] = filter(x -> x ∉ model.options.unused_varshks, unused[k])
+        end
+    end
     return unused
 end
 export get_unused_symbols

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1435,15 +1435,6 @@ end
     @test length(m.equations) == 3
     @test collect(keys(m.equations)) == [:_EQ1, :_EQ3, :_EQ4]
 
-    m = S1.newmodel()
-    @equations m begin
-        @delete _EQ1
-    end
-    @steadystate m begin
-        @delete _SSEQ1
-    end
-    @test_logs (:warn, "Model contains unused variables: [:a]") @reinitialize m
-
 
     maux = deepcopy(AUX.model)
     @test length(maux.equations) == 2
@@ -1458,6 +1449,30 @@ end
     end
     @test length(maux.equations) == 2
     @test length(maux.alleqns) == 4
+
+    # option to not show a warning
+    m = S1.newmodel()
+
+    @equations m begin
+        @delete _EQ2
+    end
+
+    @test length(m.equations) == 2
+    @test collect(keys(m.equations)) == [:_EQ1, :_EQ3]
+    m.options.unused_varshks = [:b_shk]
+
+    @test_logs @reinitialize m
+
+     # option to not show a warning
+    m = S1.newmodel()
+    @equations m begin
+        @delete _EQ1
+    end
+    @steadystate m begin
+        @delete _SSEQ1
+    end
+    m.options.unused_varshks = [:a]
+    @test_logs @reinitialize m
 end
 
 @using_example E2sat


### PR DESCRIPTION
This is a small fix that adds an option to the model `unused_varshks` which takes a vector of symbols (or in theory another iterable).

Any symbols within this vector will no longer throw a warning when `@initialize` or `@reinitialize` is called and the corresponding variable is not being used in the model equations.

This solves an issue when some variables are needed for the steadystate but are not present in the model equations.

Tests were also added to verify this behavior.

We may want to change the naming convention here.
