### PR TITLE
Avoid regeneration of functions for known equations

### DIFF
--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -103,9 +103,9 @@ function moduleof(m::M) where {M<:AbstractModel}
         mod_eval = m._module_eval
         isnothing(mod_eval) || return parentmodule(mod_eval(:(EquationEvaluator)))
     end
-    for (_, eqn) in equations(m)
-        mod = parentmodule(eval_resid(eqn))
-        (mod === @__MODULE__) || return mod
-    end
+    # for (_, eqn) in equations(m)
+    #     mod = parentmodule(eval_resid(eqn))
+    #     (mod === @__MODULE__) || return mod
+    # end
     error("Unable to determine the module containing the given model. Try adding equations to it and calling `@initialize`.")
 end

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -98,10 +98,14 @@ Return the module in which the given equation or model was initialized.
 """
 function moduleof end
 moduleof(e::AbstractEquation) = parentmodule(eval_resid(e))
-function moduleof(m::AbstractModel)
-    eqns = equations(m)
-    if isempty(eqns)
-        error("Unable to determine the module containing the given model. Try adding equations to it and call `@initialize`.")
+function moduleof(m::M) where {M<:AbstractModel}
+    if hasfield(M, :_module_eval) 
+        mod_eval = m._module_eval
+        isnothing(mod_eval) || return parentmodule(mod_eval(:(EquationEvaluator)))
     end
-    return moduleof(first(eqns)[2])
+    for (_, eqn) in equations(m)
+        mod = parentmodule(eval_resid(eqn))
+        (mod === @__MODULE__) || return mod
+    end
+    error("Unable to determine the module containing the given model. Try adding equations to it and calling `@initialize`.")
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -54,6 +54,8 @@ mutable struct Model <: AbstractModel
     "State determines whether the model is ready to be solved/run. One of :new, :ready, :dev. 
     Should not be directly manipulated."
     _state::Symbol
+    "the module in which all model equations will be compiled"
+    _module_eval::Union{Nothing, Function}
     "Options are various hyper-parameters for tuning the algorithms"
     options::Options
     "Flags contain meta information about the type of model"
@@ -84,10 +86,10 @@ mutable struct Model <: AbstractModel
     solverdata::LittleDictVec{Symbol,Any}
     #
     # constructor of an empty model
-    Model(opts::Options) = new(:new, merge(defaultoptions, opts),
+    Model(opts::Options) = new(:new, nothing, merge(defaultoptions, opts),
         ModelFlags(), SteadyStateData(), false, [], [], OrderedDict{Symbol,Equation}(), Parameters(), Dict(), 0, 0, [], OrderedDict{Symbol,Equation}(),
         LittleDict{Symbol,AbstractModelEvaluationData}(), LittleDict{Symbol,Any}())
-    Model() = new(:new, deepcopy(defaultoptions),
+    Model() = new(:new, nothing, deepcopy(defaultoptions),
         ModelFlags(), SteadyStateData(), false, [], [], OrderedDict{Symbol,Equation}(), Parameters(), Dict(), 0, 0, [], OrderedDict{Symbol,Equation}(),
         LittleDict{Symbol,AbstractModelEvaluationData}(), LittleDict{Symbol,Any}())
 end
@@ -809,9 +811,6 @@ macro equations(model, block::Expr)
     ret = Expr(:block)
     removals, additions = parse_equation_deletes(block)
 
-    # store modelmodule in case we start removing equations
-    push!(ret.args, :(_ModelBaseEcon_temp_modelmodule = nequations($(model)) > 0 && $(thismodule).moduleof($(model)) !== $(thismodule) ? $(thismodule).moduleof($(model)) : $(__module__) ))
-
     #removals
     if length(removals.args) > 0
         push!(ret.args, :($(thismodule).deleteequations!($(model), $(removals.args))))
@@ -845,10 +844,10 @@ macro equations(model, block::Expr)
             eqn = Expr(:block)
         end
     end
-    push!(ret.args, :($(thismodule).process_new_equations!($(model), _ModelBaseEcon_temp_modelmodule); $(thismodule).update_model_state!($(model)); nothing))
+    push!(ret.args,
+        :($(thismodule).process_new_equations!($(model))),
+        :($(thismodule).update_model_state!($(model)); nothing))
 
-    # unstore modelmodule
-    push!(ret.args, :(_ModelBaseEcon_temp_modelmodule = nothing))
     return esc(ret)
 end
 
@@ -860,20 +859,18 @@ function changeequations!(eqns::OrderedDict{Symbol,Equation}, (sym, e)::Pair{Sym
     return eqns
 end
 
-function process_new_equations!(model::Model, modelmodule::Module=moduleof(model))
+function process_new_equations!(model::Model)
     # only process at this point if model is not new
     if model._state == :new
         return
     end
-    if !isdefined(modelmodule, :EquationEvaluator)
-        initfuncs(modelmodule)
-    end
+    modelmodule = moduleof(model)
     var_to_idx = _make_var_to_idx(model.allvars)
     for (key, e) in alleqns(model)
         if e.eval_resid == eqnnotready
             delete_sstate_equations!(model, key)
             delete_aux_equations!(model, key)
-            add_equation!(model, key, e.expr; modelmodule=modelmodule, var_to_idx=var_to_idx)
+            add_equation!(model, key, e.expr; modelmodule, var_to_idx)
         end
     end
 end
@@ -1170,20 +1167,10 @@ function process_equation(model::Model, expr::Expr;
     if eqn_name == :_unnamed_equation_
         throw(ArgumentError("No equation name specified"))
     end
-    if !isdefined(modelmodule, :_expression_functions_map) || modelmodule._expression_functions_map === nothing
-        @eval modelmodule _expression_functions_map = Dict{Expr,Any}()
-    end
-    if expr ∈ keys(modelmodule._expression_functions_map)
-        resid, RJ, resid_param, chunk = modelmodule._expression_functions_map[expr]
-        _update_eqn_params!(resid, model.parameters)
-    else
-        funcs_expr = makefuncs(eqn_name, residual, tssyms, sssyms, psyms, modelmodule)
-        resid, RJ, resid_param, chunk = modelmodule.eval(funcs_expr)
-        modelmodule._expression_functions_map[expr] = (resid, RJ, resid_param, chunk)
-        _update_eqn_params!(resid, model.parameters)
-        thismodule = @__MODULE__
-        modelmodule.eval(:($(thismodule).precompilefuncs($resid, $RJ, $resid_param, $chunk)))
-    end
+    resid, RJ, resid_param, chunk = makefuncs(eqn_name, residual, tssyms, sssyms, psyms, modelmodule)
+    _update_eqn_params!(resid, model.parameters)
+    thismodule = @__MODULE__
+    modelmodule.eval(:($(thismodule).precompilefuncs($resid, $RJ, $resid_param, $chunk)))
     tsrefs′ = LittleDict{Tuple{ModelSymbol,Int},Symbol}()
     for ((modsym, i), sym) in tsrefs
         tsrefs′[(ModelSymbol(modsym), i)] = sym
@@ -1397,6 +1384,7 @@ function initialize!(model::Model, modelmodule::Module)
         modelerror("Model already initialized.")
     end
     initfuncs(modelmodule)
+    model._module_eval = modelmodule.eval
     samename = Symbol[intersect(model.allvars, keys(model.parameters))...]
     if !isempty(samename)
         modelerror("Found $(length(samename)) names that are both variables and parameters: $(join(samename, ", "))")
@@ -1445,7 +1433,6 @@ some other module, then this can be done by calling this function instead of the
 macro.
 """
 function reinitialize!(model::Model, modelmodule::Module=moduleof(model))
-    initfuncs(modelmodule)
     samename = Symbol[intersect(model.allvars, keys(model.parameters))...]
     if !isempty(samename)
         modelerror("Found $(length(samename)) names that are both variables and parameters: $(join(samename, ", "))")
@@ -1492,7 +1479,7 @@ end
 Prepare a model instance for analysis. Call this macro after all parameters,
 variable names, shock names and equations have been declared and defined.
 """
-macro initialize(model::Symbol)
+macro initialize(model)
     thismodule = @__MODULE__
     # @__MODULE__ is this module (ModelBaseEcon)
     # __module__ is the module where this macro is called (the module where the model exists)
@@ -1509,7 +1496,7 @@ equations, autoexogenize lists, and removed steadystate equations have been decl
 
 Additional/new steadystate constraints can be added after the call to `@reinitialize`.
 """
-macro reinitialize(model::Symbol)
+macro reinitialize(model)
     thismodule = @__MODULE__
     # @__MODULE__ is this module (ModelBaseEcon)
     # __module__ is the module where this macro is called (the module where the model exists)

--- a/src/model.jl
+++ b/src/model.jl
@@ -1162,16 +1162,16 @@ function process_equation(model::Model, expr::Expr;
     if eqn_name == :_unnamed_equation_
         throw(ArgumentError("No equation name specified"))
     end
-    if !isdefined(modelmodule, :expression_functions_map) || modelmodule.expression_functions_map === nothing
-        modelmodule.expression_functions_map = Dict{Expr,Any}()
+    if !isdefined(modelmodule, :_expression_functions_map) || modelmodule._expression_functions_map === nothing
+        @eval modelmodule _expression_functions_map = Dict{Expr,Any}()
     end
-    if expr ∈ keys(modelmodule.expression_functions_map)
-        resid, RJ, resid_param, chunk = modelmodule.expression_functions_map[expr]
+    if expr ∈ keys(modelmodule._expression_functions_map)
+        resid, RJ, resid_param, chunk = modelmodule._expression_functions_map[expr]
         _update_eqn_params!(resid, model.parameters)
     else
         funcs_expr = makefuncs(eqn_name, residual, tssyms, sssyms, psyms, modelmodule)
         resid, RJ, resid_param, chunk = modelmodule.eval(funcs_expr)
-        modelmodule.expression_functions_map[expr] = (resid, RJ, resid_param, chunk)
+        modelmodule._expression_functions_map[expr] = (resid, RJ, resid_param, chunk)
         _update_eqn_params!(resid, model.parameters)
         thismodule = @__MODULE__
         modelmodule.eval(:($(thismodule).precompilefuncs($resid, $RJ, $resid_param, $chunk)))

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -608,15 +608,23 @@ function setss!(model::AbstractModel, expr::Expr; type::Symbol, modelmodule::Mod
     # create the resid and RJ functions for the new equation
     # To do this, we use `makefuncs` from evaluation.jl
     residual = Expr(:block, source[1], :($(lhs) - $(rhs)))
-    if !isdefined(modelmodule, :_expression_functions_map) || modelmodule._expression_functions_map === nothing
-        @eval modelmodule _expression_functions_map = Dict{Expr,Any}()
+    # Get model module from Main
+    _modelmodule = modelmodule
+    if :modulename ∈ keys(model.options) && isdefined(Main, model.options.modulename)
+        modelmodule_from_main = getfield(Main, model.options.modulename)
+        if modelmodule_from_main isa Module
+            _modelmodule = modelmodule_from_main
+        end
     end
-    if expr ∈ keys(modelmodule._expression_functions_map)
-        resid, RJ = modelmodule._expression_functions_map[expr]
+    if !isdefined(_modelmodule, :_expression_functions_map) || _modelmodule._expression_functions_map === nothing
+        @eval _modelmodule _expression_functions_map = Dict{Expr,Any}()
+    end
+    if expr ∈ keys(_modelmodule._expression_functions_map)
+        resid, RJ = _modelmodule._expression_functions_map[expr]
     else
-        funcs_expr = makefuncs(eqn_key, residual, vsyms, [], unique(val_params), modelmodule)
-        resid, RJ = modelmodule.eval(funcs_expr)
-        modelmodule._expression_functions_map[expr] = (resid, RJ)
+        funcs_expr = makefuncs(eqn_key, residual, vsyms, [], unique(val_params), _modelmodule)
+        resid, RJ = _modelmodule.eval(funcs_expr)
+        _modelmodule._expression_functions_map[expr] = (resid, RJ)
     end
     _update_eqn_params!(resid, model.parameters)
     # We have all the ingredients to create the instance of SteadyStateEquation

--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -608,15 +608,15 @@ function setss!(model::AbstractModel, expr::Expr; type::Symbol, modelmodule::Mod
     # create the resid and RJ functions for the new equation
     # To do this, we use `makefuncs` from evaluation.jl
     residual = Expr(:block, source[1], :($(lhs) - $(rhs)))
-    if !isdefined(modelmodule, :expression_functions_map) || modelmodule.expression_functions_map === nothing
-        modelmodule.expression_functions_map = Dict{Expr,Any}()
+    if !isdefined(modelmodule, :_expression_functions_map) || modelmodule._expression_functions_map === nothing
+        @eval modelmodule _expression_functions_map = Dict{Expr,Any}()
     end
-    if expr ∈ keys(modelmodule.expression_functions_map)
-        resid, RJ = modelmodule.expression_functions_map[expr]
+    if expr ∈ keys(modelmodule._expression_functions_map)
+        resid, RJ = modelmodule._expression_functions_map[expr]
     else
         funcs_expr = makefuncs(eqn_key, residual, vsyms, [], unique(val_params), modelmodule)
         resid, RJ = modelmodule.eval(funcs_expr)
-        modelmodule.expression_functions_map[expr] = (resid, RJ)
+        modelmodule._expression_functions_map[expr] = (resid, RJ)
     end
     _update_eqn_params!(resid, model.parameters)
     # We have all the ingredients to create the instance of SteadyStateEquation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -942,11 +942,13 @@ end
 
 # helper functions
 function get_max_maineq()
-    tmp = InteractiveUtils.varinfo(@__MODULE__)
-    tmp = filter(r -> match(r"resid_maineq_\d+$", r[1]) !== nothing, tmp.content[1].rows[2:end])
+    mod = @__MODULE__
+    all_names = names(mod, all=true)
+    method_names = filter(name -> isa(getfield(mod, name), Function), all_names)
+    resid_funcs = filter(r -> match(r"resid_maineq_\d+$", r) !== nothing, string.(method_names))
     versions = Vector{Int64}([0])
-    for v in tmp
-        _m = match(r"resid_maineq_(\d+)$", v[1])
+    for v in resid_funcs
+        _m = match(r"resid_maineq_(\d+)$", v)
         if _m !== nothing
           push!(versions, parse(Int64,_m[1]))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -961,20 +961,20 @@ end
     # remove existing key (from repeated test runs)
     mod = @__MODULE__
     eq_key = :(y[t] = 0.132434 * y[t - 1] + (0.8675660000000001 * y[t + 1] + y_shk[t]))
-    if eq_key ∈ keys(mod.expression_functions_map)
-        delete!(mod.expression_functions_map, eq_key)
+    if eq_key ∈ keys(mod._expression_functions_map)
+        delete!(mod._expression_functions_map, eq_key)
     end
 
     for i = 1:3
         α = 0.132434
         new_E1 = E1_noparams.newmodel()
-        prev_length = length(mod.expression_functions_map)
+        prev_length = length(mod._expression_functions_map)
         prev_maxversion = get_max_maineq()
         @equations new_E1 begin
             :maineq => y[t] = $α * y[t-1] + $(1 - α) * y[t+1] + y_shk[t]
         end
         @reinitialize(new_E1)
-        new_length = length(mod.expression_functions_map)
+        new_length = length(mod._expression_functions_map)
         new_maxversion = get_max_maineq()
         if i == 1
             @test new_length == prev_length + 1


### PR DESCRIPTION
The model change syntax can introduce excessive function generation if the model changes are run repeatedly; we will generate new `resid`, `RJ`, and `resid_param` functions and evaluate and precompile these every time an equation is changed even if we are just repeatedly running the same model change block. 

This fix introduces a new variable `_expression_functions_map` at the current modelmodule level (i.e. LENS or Main) which simply keeps track of the generated functions and indexes them by the expression used in the equation from which they were generated.

This is a relatively naïve approach as non-functional changes to the expression would lead to a new entry in the list, but it does fix the issue of generating new unnecessary functions when repeatedly running the same code.

Preventing this is particularly relevant when running the model change code across a main thread and multiple workers. Without this check, the main thread may have run the model changes additional times and will expect a newer version of these functions (i.e. `resid__EQ1_4`) than is present on the workers (i.e. `resid__EQ1_2`). The brute force fix is to check the difference in these numbers and ensure that the model changes have been run a sufficient number of times on the workers. The fix in this PR is slightly more elegant by preventing multiple `resid` functions for the exact same expression. 

The PR also adds a new option to the model `o.modulename`. If specified, the code will try to get the module with the same name from Main and use that as `modelmodule` when checking/updating `_expression_functions_map` and the equations themselves.