### PR TITLE
Fix issues with equation parentheses

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -824,14 +824,14 @@ function split_doc_tag_eqn(expr)
         _, src, doc, expr = expr.args
     end
     # local tag, eqtyp, lhs, rhs
-    if @capture(expr, @eqtyp_ lhs_ = rhs_)
+    if @capture(expr, @eqtyp_ lhs_ = rhs_) || @capture(expr, (@eqtyp_ lhs_ = rhs_))
         tag = :(:_unnamed_equation_)
         eqn = Expr(:macrocall, eqtyp, expr.args[2], :($lhs = $rhs))
-    elseif @capture(expr, tag_ => @eqtyp_ lhs_ = rhs_)
+    elseif @capture(expr, tag_ => @eqtyp_ lhs_ = rhs_) || @capture(expr, tag_ => (@eqtyp_ lhs_ = rhs_))
         eqn = Expr(:macrocall, eqtyp, expr.args[3].args[2], :($lhs = $rhs))
-    elseif @capture(expr, tag_ => lhs_ = rhs_)
+    elseif @capture(expr, tag_ => lhs_ = rhs_) || @capture(expr, tag_ => (lhs_ = rhs_))
         eqn = :($lhs = $rhs)
-    elseif @capture(expr, lhs_ = rhs_)
+    elseif @capture(expr, lhs_ = rhs_) || @capture(expr, (lhs_ = rhs_))
         tag = :(:_unnamed_equation_)
         eqn = :($lhs = $rhs)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1729,3 +1729,18 @@ end
         @test 0 == eq.eval_resid(x)
     end
 end
+
+@testset "equation_parentheses" begin
+    @test let model = Model()
+        @variables model x
+        @equations model begin
+            :EQ_x1 => (x[t] = 0)
+            (x[t] = 0)
+            :EQ_x1 => (@lin x[t] = 0)
+            (@lin x[t] = 0)
+        end
+        @initialize(model)
+        true
+    end
+end
+nothing


### PR DESCRIPTION
We had a parsing error when the entire equation was wrapped inside parentheses. `ModelBaseEcon.jl` was not recognizing it as an expression. We covered all four cases: with and without tags, with and without `@lin`.

For instance, the model below shows all 4 cases that failed before:

```julia
module A
    using ModelBaseEcon
    const model = Model()
    @variables model x
    @equations model begin
        :EQ_x1 => (x[t] = 0)
        (x[t] = 0)
        :EQ_x1 => (@lin x[t] = 0)
        (@lin x[t] = 0)
    end
    @initialize(model)
end
```