### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/variables.jl
+++ b/src/variables.jl
@@ -250,7 +250,6 @@ Base.:(==)(a::Symbol, b::ModelVariable) = (@nospecialize; a == b.name)
 # The hash must be the same as the hash of the symbol, so that we can use
 # ModelVariable as index in a Dict with Symbol keys
 Base.hash(v::ModelVariable, h::UInt) = (@nospecialize; hash(v.name, h))
-Base.hash(v::ModelVariable) = (@nospecialize; hash(v.name))
 
 function Base.show(io::IO, v::ModelVariable)
     @nospecialize(v)


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.